### PR TITLE
Disable Automatic Running of Docker Builders

### DIFF
--- a/.github/workflows/docker_jetpack.yml
+++ b/.github/workflows/docker_jetpack.yml
@@ -1,11 +1,6 @@
 name: Build and Publish JetPack Dockerfile
 
 on:
-  # Runs workflow 'automatically' when a pull request for the development
-  # branch is made and documentaion files have been edited.
-  pull_request:
-    branches: ["development"]
-    paths: [".devcontainer/Dockerfile_JetPack"]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docker_ubuntu.yml
+++ b/.github/workflows/docker_ubuntu.yml
@@ -1,11 +1,6 @@
 name: Build and Publish Ubuntu Dockerfile
 
 on:
-  # Runs workflow 'automatically' when a pull request for the development
-  # branch is made and documentaion files have been edited.
-  pull_request:
-    branches: ["development"]
-    paths: [".devcontainer/Dockerfile_Ubuntu"]
   workflow_dispatch:
 
 permissions:
@@ -30,7 +25,6 @@ jobs:
     steps:
       - name: Get commits
         env:
-          # github URL to list commits
           COMMITS_URL: ${{ github.event.pull_request.commits_url }}
         run: |
           if [ "${COMMITS_URL}x" != "x" ]; then


### PR DESCRIPTION
Make it so that the docker builder has to be run via a manual start from the GitHub Actions Panel. This is to prevent the error that occurs when the number of commits goes into the next "set of 100".

Due to the few number of times this will need to be run, it makes since to have it run manually.