### PR TITLE
Switch RoveComm_CPP from submodule to CMake Static Library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/RoveComm_CPP"]
-	path = external/RoveComm_CPP
-	url = https://github.com/MissouriMRDT/RoveComm_CPP.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,81 +7,81 @@
 
 
 ## Set CMake Minimum Version
-CMAKE_MINIMUM_REQUIRED(VERSION 3.24.3)
+cmake_minimum_required(VERSION 3.24.3)
 
 ## C++ Version
-SET(CMAKE_CXX_STANDARD 20)
-SET(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ## Project Name and Software Version Number
-PROJECT(Autonomy_Software VERSION 24.00.00)
+project(Autonomy_Software VERSION 24.00.00)
 
 ## Include Required CMake Packages
-INCLUDE(CPack)																		# CMake Packaging Library
-INCLUDE(CTest)																	  	# CMake Testing Framework
-INCLUDE(FetchContent)															   	# CMake Dependency Framework
+include(CPack)																		# CMake Packaging Library
+include(CTest)																	  	# CMake Testing Framework
+include(FetchContent)															   	# CMake Dependency Framework
 
 ## Define Project Name and Version Number for CPack
-SET(CPACK_PROJECT_NAME ${PROJECT_NAME})
-SET(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
-SET(CPACK_PACKAGE_VENDOR "Mars Rover Design Team")
-SET(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
-SET(CPACK_GENERATOR "SH")
+set(CPACK_PROJECT_NAME ${PROJECT_NAME})
+set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
+set(CPACK_PACKAGE_VENDOR "Mars Rover Design Team")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+set(CPACK_GENERATOR "SH")
 
 ## Find Threads
-FIND_PACKAGE(Threads REQUIRED)
+find_package(Threads REQUIRED)
 
 ## Find Quill
-FIND_PACKAGE(quill REQUIRED)
+find_package(quill REQUIRED)
 
 ## Find Google Test
-FIND_PACKAGE(GTest CONFIG REQUIRED)
-INCLUDE(GoogleTest)
+find_package(GTest CONFIG REQUIRED)
+include(GoogleTest)
 add_library(GTest::GTest INTERFACE IMPORTED)
 target_link_libraries(GTest::GTest INTERFACE gtest_main)
 
 ## Find Eigen3.
-FIND_PACKAGE(Eigen3 3.3 REQUIRED NO_MODULE)
+find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 
 ## Find OpenCV
-FIND_PACKAGE( OpenCV REQUIRED )
-INCLUDE_DIRECTORIES( ${OpenCV_INCLUDE_DIRS} )
+find_package( OpenCV REQUIRED )
+include_directories( ${OpenCV_INCLUDE_DIRS} )
 
 ## Enable to CTest and Google Test Frameworks
-ENABLE_TESTING()
+enable_testing()
 
 ## Search Project Directories for CPP Files
-FILE(GLOB Algorithms_SRC		CONFIGURE_DEPENDS  "src/algorithms/*.cpp")
-FILE(GLOB Interfaces_SRC		CONFIGURE_DEPENDS  "src/interfaces/*.cpp")
-FILE(GLOB States_SRC			CONFIGURE_DEPENDS  "src/states/*.cpp")
-FILE(GLOB Util_SRC			  	CONFIGURE_DEPENDS  "src/util/*.cpp")
-FILE(GLOB Vision_SRC			CONFIGURE_DEPENDS  "src/vision/*.cpp")
-FILE(GLOB Main_SRC			  	CONFIGURE_DEPENDS  "src/*.cpp")
-FILE(GLOB Examples_SRC		  	CONFIGURE_DEPENDS  "examples/*/*.cpp")
-FILE(GLOB External_SRC		  	CONFIGURE_DEPENDS  "external/src/*.cpp")
-FILE(GLOB Tools_SRC			 	CONFIGURE_DEPENDS  "tools/*.cpp")
+file(GLOB Algorithms_SRC		CONFIGURE_DEPENDS  "src/algorithms/*.cpp")
+file(GLOB Interfaces_SRC		CONFIGURE_DEPENDS  "src/interfaces/*.cpp")
+file(GLOB States_SRC			CONFIGURE_DEPENDS  "src/states/*.cpp")
+file(GLOB Util_SRC			  	CONFIGURE_DEPENDS  "src/util/*.cpp")
+file(GLOB Vision_SRC			CONFIGURE_DEPENDS  "src/vision/*.cpp")
+file(GLOB Main_SRC			  	CONFIGURE_DEPENDS  "src/*.cpp")
+file(GLOB Examples_SRC		  	CONFIGURE_DEPENDS  "examples/*/*.cpp")
+file(GLOB External_SRC		  	CONFIGURE_DEPENDS  "external/src/*.cpp")
+file(GLOB Tools_SRC			 	CONFIGURE_DEPENDS  "tools/*.cpp")
 
 ## Create Executable File
-ADD_EXECUTABLE(${PROJECT_NAME}   ${External_SRC}
-								 ${Util_SRC}
-								 ${Algorithms_SRC}
-								 ${Interfaces_SRC}
-								 ${States_SRC}
-								 ${Vision_SRC}
-								 ${Main_SRC}
-								 ${Examples_SRC}
-								 ${Tools_SRC}
+add_executable(${PROJECT_NAME}  ${External_SRC}
+								${Util_SRC}
+								${Algorithms_SRC}
+								${Interfaces_SRC}
+								${States_SRC}
+								${Vision_SRC}
+								${Main_SRC}
+								${Examples_SRC}
+								${Tools_SRC}
 	)
 
 ## Set Compile Options for Autonomy Software.
-IF(MSVC) # True when compiler is Microsoft Visual C++/simulation of Visual C++ CL.
-	TARGET_COMPILE_OPTIONS(${PROJECT_NAME} PRIVATE /W4 /WX)
-ELSE()
-	TARGET_COMPILE_OPTIONS(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic)
-ENDIF()
+if(MSVC) # True when compiler is Microsoft Visual C++/simulation of Visual C++ CL.
+	target_compile_options(${PROJECT_NAME} PRIVATE /W4 /WX)
+else()
+	target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Wpedantic)
+endif()
 
 ## Link Libraries to Executable
-TARGET_LINK_LIBRARIES(${PROJECT_NAME} PRIVATE   Threads::Threads
+target_link_libraries(${PROJECT_NAME} PRIVATE   Threads::Threads
 												Eigen3::Eigen
                                                 quill::quill
 												${OpenCV_LIBS}
@@ -89,23 +89,23 @@ TARGET_LINK_LIBRARIES(${PROJECT_NAME} PRIVATE   Threads::Threads
     )
 
 ## Package Executable
-INSTALL(TARGETS ${PROJECT_NAME} RUNTIME_DEPENDENCIES DIRECTORIES ${OpenCV_LIBS} quill::quill RUNTIME DESTINATION bin )
+install(TARGETS ${PROJECT_NAME} RUNTIME_DEPENDENCIES DIRECTORIES ${OpenCV_LIBS} quill::quill RUNTIME DESTINATION bin)
 
 ## Unit/Integration Tests
-FILE(GLOB UnitTests_SRC         CONFIGURE_DEPENDS  "tests/Unit/**/*.cc")
-FILE(GLOB IntegrationTests_SRC  CONFIGURE_DEPENDS  "tests/Integration/**/*.cc")
+file(GLOB UnitTests_SRC         CONFIGURE_DEPENDS  "tests/Unit/**/*.cc")
+file(GLOB IntegrationTests_SRC  CONFIGURE_DEPENDS  "tests/Integration/**/*.cc")
 
-LIST(LENGTH UnitTests_SRC           UnitTests_LEN)
-LIST(LENGTH IntegrationTests_SRC    IntegrationTests_LEN)
+list(LENGTH UnitTests_SRC           UnitTests_LEN)
+list(LENGTH IntegrationTests_SRC    IntegrationTests_LEN)
 
-IF (UnitTests_LEN GREATER 0)
-    ADD_EXECUTABLE(${PROJECT_NAME}_UnitTests "tests/Unit/main.cc" ${UnitTests_SRC})
-    TARGET_LINK_LIBRARIES(${PROJECT_NAME}_UnitTests GTest::gtest GTest::gtest_main)
-    ADD_TEST(Unit_Tests ${PROJECT_NAME}_UnitTests)
-ENDIF()
+if (UnitTests_LEN GREATER 0)
+    add_executable(${PROJECT_NAME}_UnitTests "tests/Unit/main.cc" ${UnitTests_SRC})
+    target_link_libraries(${PROJECT_NAME}_UnitTests GTest::gtest GTest::gtest_main)
+    add_test(Unit_Tests ${PROJECT_NAME}_UnitTests)
+endif()
 
-IF (IntegrationTests_LEN GREATER 0)
-    ADD_EXECUTABLE(${PROJECT_NAME}_IntegrationTests "tests/Unit/main.cc" ${IntegrationTests_SRC})
-    TARGET_LINK_LIBRARIES(${PROJECT_NAME}_IntegrationTests GTest::gtest GTest::gtest_main)
-    ADD_TEST(Integration_Tests ${PROJECT_NAME}_IntegrationTests)
-ENDIF()
+if (IntegrationTests_LEN GREATER 0)
+    add_executable(${PROJECT_NAME}_IntegrationTests "tests/Unit/main.cc" ${IntegrationTests_SRC})
+    target_link_libraries(${PROJECT_NAME}_IntegrationTests GTest::gtest GTest::gtest_main)
+    add_test(Integration_Tests ${PROJECT_NAME}_IntegrationTests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ set(CPACK_GENERATOR "SH")
 ## Find RoveComm
 FetchContent_Declare(RoveComm_CPP                                                   # Custom Network Protocol (RoveComm)
         GIT_REPOSITORY https://github.com/MissouriMRDT/RoveComm_CPP.git             # Source Code URL
-        GIT_TAG        fd3b5cdaa9aeda7b9a9f632a8ffad438d8bb563c                     # Version 24.0.0
+        GIT_TAG        16ba934e74a1c18e18c565c48000481e0451a966                     # Version 24.0.0
         GIT_SHALLOW    TRUE                                                         # Download only without history
         GIT_PROGRESS   TRUE                                                         # Forces progress status.
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 project(Autonomy_Software VERSION 24.00.00)
 
 ## Include Required CMake Packages
-include(CPack)																		# CMake Packaging Library
-include(CTest)																	  	# CMake Testing Framework
-include(FetchContent)															   	# CMake Dependency Framework
+if(CPack_CMake_INCLUDED)
+    include(CPack)                                                                  # CMake Packaging Library
+endif()
+if(CTest_CMake_INCLUDED)
+    include(CTest)                                                                  # CMake Testing Framework
+endif()
+include(FetchContent)                                                               # CMake Dependency Framework
 
 ## Define Project Name and Version Number for CPack
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
@@ -27,6 +31,27 @@ set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
 set(CPACK_PACKAGE_VENDOR "Mars Rover Design Team")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 set(CPACK_GENERATOR "SH")
+
+## Find RoveComm
+FetchContent_Declare(RoveComm_CPP                                                   # Custom Network Protocol (RoveComm)
+        GIT_REPOSITORY https://github.com/MissouriMRDT/RoveComm_CPP.git             # Source Code URL
+        GIT_TAG        fd3b5cdaa9aeda7b9a9f632a8ffad438d8bb563c                     # Version 24.0.0
+        GIT_SHALLOW    TRUE                                                         # Download only without history
+        GIT_PROGRESS   TRUE                                                         # Forces progress status.
+    )
+FetchContent_GetProperties(RoveComm_CPP)
+if(NOT RoveComm_CPP)
+    # Fetch the content using previously declared details
+    FetchContent_Populate(RoveComm_CPP)
+
+    # Set Library Scope
+    set(RoveComm_CPP_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/_deps/rovecomm_cpp-src/src)
+    set(RoveComm_CPP_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/_deps/rovecomm_cpp-src)
+
+    # Bring the populated content into the build
+    include_directories( ${RoveComm_CPP_INCLUDE_DIR} )
+    add_subdirectory(${RoveComm_CPP_SOURCE_DIR})
+endif()
 
 ## Find Threads
 find_package(Threads REQUIRED)
@@ -58,12 +83,10 @@ file(GLOB Util_SRC			  	CONFIGURE_DEPENDS  "src/util/*.cpp")
 file(GLOB Vision_SRC			CONFIGURE_DEPENDS  "src/vision/*.cpp")
 file(GLOB Main_SRC			  	CONFIGURE_DEPENDS  "src/*.cpp")
 file(GLOB Examples_SRC		  	CONFIGURE_DEPENDS  "examples/*/*.cpp")
-file(GLOB External_SRC		  	CONFIGURE_DEPENDS  "external/src/*.cpp")
 file(GLOB Tools_SRC			 	CONFIGURE_DEPENDS  "tools/*.cpp")
 
 ## Create Executable File
-add_executable(${PROJECT_NAME}  ${External_SRC}
-								${Util_SRC}
+add_executable(${PROJECT_NAME}  ${Util_SRC}
 								${Algorithms_SRC}
 								${Interfaces_SRC}
 								${States_SRC}
@@ -85,11 +108,12 @@ target_link_libraries(${PROJECT_NAME} PRIVATE   Threads::Threads
 												Eigen3::Eigen
                                                 quill::quill
 												${OpenCV_LIBS}
+                                                RoveComm_CPP
                                                 #Boost::filesystem
     )
 
 ## Package Executable
-install(TARGETS ${PROJECT_NAME} RUNTIME_DEPENDENCIES DIRECTORIES ${OpenCV_LIBS} quill::quill RUNTIME DESTINATION bin)
+install(TARGETS ${PROJECT_NAME} RUNTIME_DEPENDENCIES DIRECTORIES ${OpenCV_LIBS} quill::quill RoveComm_CPP RUNTIME DESTINATION bin)
 
 ## Unit/Integration Tests
 file(GLOB UnitTests_SRC         CONFIGURE_DEPENDS  "tests/Unit/**/*.cc")


### PR DESCRIPTION
Revamped [RoveComm_CPP](https://github.com/MissouriMRDT/RoveComm_CPP) to be built as a CMake Static Library that is imported into the project when CMake is configured. See [RoveComm_CPP PR#1](https://github.com/MissouriMRDT/RoveComm_CPP/pull/1) for changes that were made on the RoveComm side.

closes #32 