### PR TITLE
[HOTFIX] Limit when documentation is updated.

### DIFF
--- a/.github/workflows/doxygen_generate.yml
+++ b/.github/workflows/doxygen_generate.yml
@@ -28,8 +28,9 @@ concurrency:
 jobs:
   run-doxygen:
 
-    # Only run this step if the pull request was merged
-    if: github.event.pull_request.merged == true
+    # Only run this step if the action wass triggered automatically and the pull request merged on the development branch.
+    # Or, it was triggered manually on the development branch.
+    if: ${{ github.event.pull_request.merged == true || ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/development' ) }}
     
     environment:
       name: github-pages

--- a/.github/workflows/doxygen_generate.yml
+++ b/.github/workflows/doxygen_generate.yml
@@ -2,8 +2,9 @@ name: Generate API Docs
 
 on:
   # Runs workflow 'automatically' when a pull request
-  # for the development branch is made
+  # for the development branch is closed.
   pull_request:
+    types: [closed]
     branches: ["development"]
     # Don't apply gitignore rules, this allows us to push the generated docs.
     paths-ignore:
@@ -26,6 +27,10 @@ concurrency:
 
 jobs:
   run-doxygen:
+
+    # Only run this step if the pull request was merged
+    if: github.event.pull_request.merged == true
+    
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Only allow documentation to be re-generated when a pull request is merged successfully into the development branch. Or, the action is manually triggered on the development branch.