### PR TITLE
Add "duplicate" image reference

### DIFF
--- a/src/states/README.md
+++ b/src/states/README.md
@@ -7,6 +7,7 @@ The **States** directory is intended to store C++ files related to the implement
 ## Diagram
 
 ![](../../data/README_Resources/images/state_machine_diagram.png)
+![](data/README_Resources/images/state_machine_diagram.png)
 
 ## Guidelines
 


### PR DESCRIPTION
Doxygen is run from the root directory so image/file paths have to be made based on the root directory while markdown is based on the relative scope. Only one of the two images is shown at a time.