### PR TITLE
Docker Image Updates

### DIFF
--- a/.devcontainer/Dockerfile_JetPack5
+++ b/.devcontainer/Dockerfile_JetPack5
@@ -1,44 +1,78 @@
+# Install Variables
+ARG L4T_MAJOR="5"
+ARG L4T_MINOR="1"
+ARG L4T_PATCH="1"
+ARG L4T_BASE="l4t-jetpack"
+ARG ZED_MAJOR="4"
+ARG ZED_MINOR="0"
+ARG CMAKE_VERSION="3.24.3"
+ARG OPENCV_VERSION="4.8.0"
+ARG QUILL_VERSION="v3.3.1"
+ARG GTEST_VERSION="v1.14.0"
+
 # Base Image
-FROM stereolabs/zed:4.0-tools-devel-jetson-jp5.1.1
+FROM nvcr.io/nvidia/${L4T_BASE}:r${L4T_MAJOR}.${L4T_MINOR}.${L4T_PATCH}
+
+# Set Labels
 LABEL authors="Missouri S&T Mars Rover Design Team"
 LABEL maintainer="Mars Rover Design Team <marsrover@mst.edu>"
 LABEL org.opencontainers.image.source=https://github.com/missourimrdt/autonomy_software
 LABEL org.opencontainers.image.licenses=GPL-3.0-only
-LABEL org.opencontainers.image.description="v24.0.0"
+LABEL org.opencontainers.image.version="v24.0.0"
+LABEL org.opencontainers.image.description="Docker Image for ${L4T_BASE} ${L4T_MAJOR}.${L4T_MINOR}.${L4T_PATCH} with CUDA ${CUDA_MAJOR}.${CUDA_MINOR}, ZED SDK ${ZED_MAJOR}.${ZED_MINOR}, OpenCV ${OPENCV_VERSION}, Quill ${QUILL_VERSION}, and Google Test ${GTEST_VERSION}."
+
+# Set Non-Interactive Mode
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Install Necessary Packages
+# Set Jetson Streaming Evironment Variables
+ENV LOGNAME root
+
+# Set Timezone
+RUN echo "America/Chicago" > /etc/localtime
+
+# Set L4T Version
+RUN echo "# R${L4T_MAJOR} (release), REVISION: ${L4T_MINOR}.${L4T_PATCH}" > /etc/nv_tegra_release
+
+# Install Required Ubuntu Packages
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    build-essential gfortran cmake git gdb file tar libatlas-base-dev \
-    libavcodec-dev libavformat-dev libavresample-dev libcanberra-gtk3-module \
-    libdc1394-22-dev libeigen3-dev libglew-dev libgstreamer-plugins-base1.0-dev \
-    libgstreamer-plugins-good1.0-dev libgstreamer1.0-dev libgtk-3-dev libjpeg-dev \
+    build-essential gfortran cmake git gdb file tar libatlas-base-dev apt-transport-https  \
+    libavcodec-dev libavformat-dev libavresample-dev libcanberra-gtk3-module zstd wget less \
+    libdc1394-22-dev libeigen3-dev libglew-dev libgstreamer-plugins-base1.0-dev udev \
+    libgstreamer-plugins-good1.0-dev libgstreamer1.0-dev libgtk-3-dev libjpeg-dev sudo \
     libjpeg8-dev libjpeg-turbo8-dev liblapack-dev liblapacke-dev libopenblas-dev libpng-dev \
     libpostproc-dev libswscale-dev libtbb-dev libtbb2 libtesseract-dev libtiff-dev libv4l-dev \
     libxine2-dev libxvidcore-dev libx264-dev libgtkglext1 libgtkglext1-dev pkg-config qv4l2 \
     v4l-utils zlib1g-dev python3-dev python-numpy libboost-all-dev valgrind doxygen graphviz nano
 
+#This symbolic link is needed to use the streaming features on Jetson inside a container
+RUN ln -sf /usr/lib/aarch64-linux-gnu/tegra/libv4l2.so.0 /usr/lib/aarch64-linux-gnu/libv4l2.so
+
 # Install gcc/g++
 RUN apt-get install  --no-install-recommends -y \
     gcc-10 g++-10 && \
-    rm -rf /var/lib/apt/lists/*
-# Update gcc and g++ to alternatively point to gcc/g++ 10 install.
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
-
-# Install CMake
-ARG INSTALL_CMAKE_VERSION_FROM_SOURCE="3.24.3"
-COPY install-cmake.sh /tmp/
-
-RUN if [ "${INSTALL_CMAKE_VERSION_FROM_SOURCE}" != "none" ]; then \
-    chmod +x /tmp/install-cmake.sh && /tmp/install-cmake.sh ${INSTALL_CMAKE_VERSION_FROM_SOURCE}; \
-    fi && \
-    rm -f /tmp/install-cmake.sh
+    rm -rf /var/lib/apt/lists/* && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
 
 # Set Working Directory
 WORKDIR /opt
 
-# Install OpenCV from Source
-ARG OPENCV_VERSION="4.8.0"
+# Install CMake
+COPY install-cmake.sh .
+RUN if [ "${CMAKE_VERSION}" != "none" ]; then \
+    chmod +x install-cmake.sh && install-cmake.sh ${CMAKE_VERSION}; \
+    fi && \
+    rm -f install-cmake.sh
+
+# Install ZED SDK
+RUN wget -q --no-check-certificate -O ZED_SDK_Linux.run \
+    https://download.stereolabs.com/zedsdk/${ZED_MAJOR}.${ZED_MINOR}/l4t${L4T_MAJOR}.${L4T_MINOR}/jetsons && \
+    chmod +x ZED_SDK_Linux.run ; ./ZED_SDK_Linux.run silent skip_drivers && \
+    rm -rf /usr/local/zed/resources/* \
+    rm -rf ZED_SDK_Linux.run && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /root/Documents/ZED/
+
+# Install OpenCV
 RUN git clone --depth 1 --branch ${OPENCV_VERSION} https://github.com/opencv/opencv.git && \
     git clone --depth 1 --branch ${OPENCV_VERSION} https://github.com/opencv/opencv_contrib.git && \
     mkdir opencv/build && cd opencv/build && \
@@ -73,7 +107,6 @@ RUN git clone --depth 1 --branch ${OPENCV_VERSION} https://github.com/opencv/ope
     rm -rf opencv_contrib && rm -rf opencv
 
 # Install Quill from Source
-ARG QUILL_VERSION="v3.3.1"
 RUN git clone --depth 1 --branch ${QUILL_VERSION} http://github.com/odygrd/quill.git && \
     mkdir quill/build && \
     cd quill/build && \
@@ -84,8 +117,7 @@ RUN git clone --depth 1 --branch ${QUILL_VERSION} http://github.com/odygrd/quill
     rm -rf quill
 
 # Install Google Test from Source
-ARG GOOGLE_TEST_VERSION="v1.14.0"
-RUN git clone --depth 1 --branch ${GOOGLE_TEST_VERSION} https://github.com/google/googletest.git && \
+RUN git clone --depth 1 --branch ${GTEST_VERSION} https://github.com/google/googletest.git && \
     mkdir googletest/build && \
     cd googletest/build && \
     cmake .. && \
@@ -94,11 +126,11 @@ RUN git clone --depth 1 --branch ${GOOGLE_TEST_VERSION} https://github.com/googl
     cd ../.. && \
     rm -rf googletest
 
-# Set Linux Environment Variable for Make Threads. Runs everytime a terminal is opened.
+# Enable Make Threads
 RUN echo 'export MAKEFLAGS=-j$(($(grep -c "^processor" /proc/cpuinfo) - 1))' >> .bashrc
 
-# Clone your C++ project repository
+# Clone Autonomy Software Repository
 RUN git clone --recurse-submodules -j8 https://github.com/MissouriMRDT/Autonomy_Software.git
 
-# Set the working directory TO BUILD
+# Set Working Directory
 WORKDIR /Autonomy_Software/

--- a/.devcontainer/Dockerfile_JetPack5
+++ b/.devcontainer/Dockerfile_JetPack5
@@ -1,3 +1,12 @@
+# Image Variables
+ARG L4T_MAJOR="5"
+ARG L4T_MINOR="1"
+ARG L4T_PATCH="1"
+ARG L4T_BASE="l4t-jetpack"
+
+# Base Image
+FROM nvcr.io/nvidia/${L4T_BASE}:r${L4T_MAJOR}.${L4T_MINOR}.${L4T_PATCH}
+
 # Install Variables
 ARG L4T_MAJOR="5"
 ARG L4T_MINOR="1"
@@ -9,9 +18,6 @@ ARG CMAKE_VERSION="3.24.3"
 ARG OPENCV_VERSION="4.8.0"
 ARG QUILL_VERSION="v3.3.1"
 ARG GTEST_VERSION="v1.14.0"
-
-# Base Image
-FROM nvcr.io/nvidia/${L4T_BASE}:r${L4T_MAJOR}.${L4T_MINOR}.${L4T_PATCH}
 
 # Set Labels
 LABEL authors="Missouri S&T Mars Rover Design Team"
@@ -37,7 +43,7 @@ RUN echo "# R${L4T_MAJOR} (release), REVISION: ${L4T_MINOR}.${L4T_PATCH}" > /etc
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential gfortran cmake git gdb file tar libatlas-base-dev apt-transport-https  \
     libavcodec-dev libavformat-dev libavresample-dev libcanberra-gtk3-module zstd wget less \
-    libdc1394-22-dev libeigen3-dev libglew-dev libgstreamer-plugins-base1.0-dev udev \
+    libdc1394-22-dev libeigen3-dev libglew-dev libgstreamer-plugins-base1.0-dev udev curl \
     libgstreamer-plugins-good1.0-dev libgstreamer1.0-dev libgtk-3-dev libjpeg-dev sudo \
     libjpeg8-dev libjpeg-turbo8-dev liblapack-dev liblapacke-dev libopenblas-dev libpng-dev \
     libpostproc-dev libswscale-dev libtbb-dev libtbb2 libtesseract-dev libtiff-dev libv4l-dev \
@@ -53,15 +59,15 @@ RUN apt-get install  --no-install-recommends -y \
     rm -rf /var/lib/apt/lists/* && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
 
+# Install CMake
+COPY install-cmake.sh /tmp/
+RUN if [ "${CMAKE_VERSION}" != "none" ]; then \
+    chmod +x /tmp/install-cmake.sh && /tmp/install-cmake.sh ${CMAKE_VERSION}; \
+    fi && \
+    rm -f /tmp/install-cmake.sh
+
 # Set Working Directory
 WORKDIR /opt
-
-# Install CMake
-COPY install-cmake.sh .
-RUN if [ "${CMAKE_VERSION}" != "none" ]; then \
-    chmod +x install-cmake.sh && install-cmake.sh ${CMAKE_VERSION}; \
-    fi && \
-    rm -f install-cmake.sh
 
 # Install ZED SDK
 RUN wget -q --no-check-certificate -O ZED_SDK_Linux.run \
@@ -130,7 +136,7 @@ RUN git clone --depth 1 --branch ${GTEST_VERSION} https://github.com/google/goog
 RUN echo 'export MAKEFLAGS=-j$(($(grep -c "^processor" /proc/cpuinfo) - 1))' >> .bashrc
 
 # Clone Autonomy Software Repository
-RUN git clone --recurse-submodules -j8 https://github.com/MissouriMRDT/Autonomy_Software.git
+RUN git clone --recurse-submodules -j8 https://github.com/MissouriMRDT/Autonomy_Software.git /opt/Autonomy_Software
 
 # Set Working Directory
-WORKDIR /Autonomy_Software/
+WORKDIR /opt/Autonomy_Software/

--- a/.devcontainer/Dockerfile_JetPack5
+++ b/.devcontainer/Dockerfile_JetPack5
@@ -1,6 +1,6 @@
 # Image Variables
-ARG L4T_MAJOR="5"
-ARG L4T_MINOR="1"
+ARG L4T_MAJOR="35"
+ARG L4T_MINOR="4"
 ARG L4T_PATCH="1"
 ARG L4T_BASE="l4t-jetpack"
 
@@ -8,8 +8,8 @@ ARG L4T_BASE="l4t-jetpack"
 FROM nvcr.io/nvidia/${L4T_BASE}:r${L4T_MAJOR}.${L4T_MINOR}.${L4T_PATCH}
 
 # Install Variables
-ARG L4T_MAJOR="5"
-ARG L4T_MINOR="1"
+ARG L4T_MAJOR="35"
+ARG L4T_MINOR="4"
 ARG L4T_PATCH="1"
 ARG L4T_BASE="l4t-jetpack"
 ARG ZED_MAJOR="4"

--- a/.devcontainer/Dockerfile_JetPack5
+++ b/.devcontainer/Dockerfile_JetPack5
@@ -1,6 +1,6 @@
 # Image Variables
 ARG L4T_MAJOR="35"
-ARG L4T_MINOR="4"
+ARG L4T_MINOR="3"
 ARG L4T_PATCH="1"
 ARG L4T_BASE="l4t-jetpack"
 
@@ -9,7 +9,7 @@ FROM nvcr.io/nvidia/${L4T_BASE}:r${L4T_MAJOR}.${L4T_MINOR}.${L4T_PATCH}
 
 # Install Variables
 ARG L4T_MAJOR="35"
-ARG L4T_MINOR="4"
+ARG L4T_MINOR="3"
 ARG L4T_PATCH="1"
 ARG L4T_BASE="l4t-jetpack"
 ARG ZED_MAJOR="4"

--- a/.devcontainer/Dockerfile_Ubuntu20
+++ b/.devcontainer/Dockerfile_Ubuntu20
@@ -1,7 +1,17 @@
+# Image Variables
+ARG UBUNTU_MAJOR="20"
+ARG CUDA_MAJOR="11"
+ARG CUDA_MINOR="7"
+ARG CUDA_PATCH="0"
+
+# Base Image
+FROM nvcr.io/nvidia/cuda:${CUDA_MAJOR}.${CUDA_MINOR}.${CUDA_PATCH}-devel-ubuntu${UBUNTU_MAJOR}.04
+
 # Install Variables
 ARG UBUNTU_MAJOR="20"
 ARG CUDA_MAJOR="11"
-ARG CUDA_MINOR="4"
+ARG CUDA_MINOR="7"
+ARG CUDA_PATCH="0"
 ARG ZED_MAJOR="4"
 ARG ZED_MINOR="0"
 ARG CMAKE_VERSION="3.24.3"
@@ -9,14 +19,11 @@ ARG OPENCV_VERSION="4.8.0"
 ARG QUILL_VERSION="v3.3.1"
 ARG GTEST_VERSION="v1.14.0"
 
-# Base Image
-FROM nvidia/cudagl:${CUDA_MAJOR}.${CUDA_MINOR}-devel-ubuntu${UBUNTU_MAJOR}.04
-
 # Set Labels
 LABEL authors="Missouri S&T Mars Rover Design Team"
 LABEL maintainer="Mars Rover Design Team <marsrover@mst.edu>"
 LABEL org.opencontainers.image.source=https://github.com/missourimrdt/autonomy_software
-LABEL org.opencontainers.image.licenses=GPL-3.0-only
+LABEL org.opencontainers.image.licenses=GPL-3.0-onlyLABEL
 LABEL org.opencontainers.image.version="v24.0.0"
 LABEL org.opencontainers.image.description="Docker Image for Ubuntu ${UBUNTU_MAJOR}.${UBUNTU_MINOR} with CUDA ${CUDA_MAJOR}.${CUDA_MINOR}, ZED SDK ${ZED_MAJOR}.${ZED_MINOR}, OpenCV ${OPENCV_VERSION}, Quill ${QUILL_VERSION}, and Google Test ${GTEST_VERSION}."
 
@@ -37,7 +44,7 @@ RUN echo "CUDA Version ${CUDA_MAJOR}.${CUDA_MINOR}.0" > /usr/local/cuda/version.
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential gdb wget less udev zstd sudo libgomp1 libswscale-dev \
     cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev \
-    libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev tzdata \
+    libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev tzdata curl \
     yasm libatlas-base-dev gfortran libpq-dev libavutil-dev libpostproc-dev \
     libxine2-dev libglew-dev libtiff5-dev zlib1g-dev cowsay locales \
     libeigen3-dev python3-dev python3-pip python3-numpy libx11-dev \
@@ -53,15 +60,15 @@ RUN apt-get install  --no-install-recommends -y \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ \
     g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
 
+# Install CMake
+COPY install-cmake.sh /tmp/
+RUN if [ "${CMAKE_VERSION}" != "none" ]; then \
+        chmod +x /tmp/install-cmake.sh && /tmp/install-cmake.sh ${CMAKE_VERSION}; \
+    fi && \
+    rm -f /tmp/install-cmake.sh
+
 # Set Working Directory
 WORKDIR /opt
-
-# Install CMake
-COPY install-cmake.sh .
-RUN if [ "${CMAKE_VERSION}" != "none" ]; then \
-        chmod +x install-cmake.sh && install-cmake.sh ${CMAKE_VERSION}; \
-    fi && \
-    rm -f install-cmake.sh
 
 # Install ZED SDK
 RUN wget -q -O ZED_SDK_Linux_Ubuntu${UBUNTU_MAJOR}.run \
@@ -139,4 +146,4 @@ RUN echo '/usr/games/fortune | /usr/games/cowsay -f `ls /workspaces/Autonomy_Sof
 RUN git clone --recurse-submodules -j8 https://github.com/MissouriMRDT/Autonomy_Software.git
 
 # Set Working Directory
-WORKDIR /Autonomy_Software/
+WORKDIR /opt/Autonomy_Software/

--- a/.devcontainer/Dockerfile_Ubuntu22
+++ b/.devcontainer/Dockerfile_Ubuntu22
@@ -146,4 +146,4 @@ RUN echo '/usr/games/fortune | /usr/games/cowsay -f `ls /workspaces/Autonomy_Sof
 RUN git clone --recurse-submodules -j8 https://github.com/MissouriMRDT/Autonomy_Software.git
 
 # Set Working Directory
-WORKDIR /Autonomy_Software/
+WORKDIR /opt/Autonomy_Software/

--- a/.devcontainer/Dockerfile_Ubuntu22
+++ b/.devcontainer/Dockerfile_Ubuntu22
@@ -1,5 +1,5 @@
 # Install Variables
-ARG UBUNTU_MAJOR="20"
+ARG UBUNTU_MAJOR="22"
 ARG CUDA_MAJOR="11"
 ARG CUDA_MINOR="4"
 ARG ZED_MAJOR="4"
@@ -16,8 +16,7 @@ FROM nvidia/cudagl:${CUDA_MAJOR}.${CUDA_MINOR}-devel-ubuntu${UBUNTU_MAJOR}.04
 LABEL authors="Missouri S&T Mars Rover Design Team"
 LABEL maintainer="Mars Rover Design Team <marsrover@mst.edu>"
 LABEL org.opencontainers.image.source=https://github.com/missourimrdt/autonomy_software
-LABEL org.opencontainers.image.licenses=GPL-3.0-only
-LABEL org.opencontainers.image.version="v24.0.0"
+LABEL org.opencontainers.image.licenses=GPL-3.0-onlyLABEL org.opencontainers.image.version="v24.0.0"
 LABEL org.opencontainers.image.description="Docker Image for Ubuntu ${UBUNTU_MAJOR}.${UBUNTU_MINOR} with CUDA ${CUDA_MAJOR}.${CUDA_MINOR}, ZED SDK ${ZED_MAJOR}.${ZED_MINOR}, OpenCV ${OPENCV_VERSION}, Quill ${QUILL_VERSION}, and Google Test ${GTEST_VERSION}."
 
 # Set Non-Interactive Mode

--- a/.devcontainer/Dockerfile_Ubuntu22
+++ b/.devcontainer/Dockerfile_Ubuntu22
@@ -1,7 +1,17 @@
+# Image Variables
+ARG UBUNTU_MAJOR="22"
+ARG CUDA_MAJOR="11"
+ARG CUDA_MINOR="7"
+ARG CUDA_PATCH="0"
+
+# Base Image
+FROM nvcr.io/nvidia/cuda:${CUDA_MAJOR}.${CUDA_MINOR}.${CUDA_PATCH}-devel-ubuntu${UBUNTU_MAJOR}.04
+
 # Install Variables
 ARG UBUNTU_MAJOR="22"
 ARG CUDA_MAJOR="11"
-ARG CUDA_MINOR="4"
+ARG CUDA_MINOR="7"
+ARG CUDA_PATCH="0"
 ARG ZED_MAJOR="4"
 ARG ZED_MINOR="0"
 ARG CMAKE_VERSION="3.24.3"
@@ -9,14 +19,12 @@ ARG OPENCV_VERSION="4.8.0"
 ARG QUILL_VERSION="v3.3.1"
 ARG GTEST_VERSION="v1.14.0"
 
-# Base Image
-FROM nvidia/cudagl:${CUDA_MAJOR}.${CUDA_MINOR}-devel-ubuntu${UBUNTU_MAJOR}.04
-
 # Set Labels
 LABEL authors="Missouri S&T Mars Rover Design Team"
 LABEL maintainer="Mars Rover Design Team <marsrover@mst.edu>"
 LABEL org.opencontainers.image.source=https://github.com/missourimrdt/autonomy_software
-LABEL org.opencontainers.image.licenses=GPL-3.0-onlyLABEL org.opencontainers.image.version="v24.0.0"
+LABEL org.opencontainers.image.licenses=GPL-3.0-onlyLABEL
+LABEL org.opencontainers.image.version="v24.0.0"
 LABEL org.opencontainers.image.description="Docker Image for Ubuntu ${UBUNTU_MAJOR}.${UBUNTU_MINOR} with CUDA ${CUDA_MAJOR}.${CUDA_MINOR}, ZED SDK ${ZED_MAJOR}.${ZED_MINOR}, OpenCV ${OPENCV_VERSION}, Quill ${QUILL_VERSION}, and Google Test ${GTEST_VERSION}."
 
 # Set Non-Interactive Mode
@@ -36,7 +44,7 @@ RUN echo "CUDA Version ${CUDA_MAJOR}.${CUDA_MINOR}.0" > /usr/local/cuda/version.
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential gdb wget less udev zstd sudo libgomp1 libswscale-dev \
     cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev \
-    libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev tzdata \
+    libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev tzdata curl \
     yasm libatlas-base-dev gfortran libpq-dev libavutil-dev libpostproc-dev \
     libxine2-dev libglew-dev libtiff5-dev zlib1g-dev cowsay locales \
     libeigen3-dev python3-dev python3-pip python3-numpy libx11-dev \
@@ -52,15 +60,15 @@ RUN apt-get install  --no-install-recommends -y \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ \
     g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
 
+# Install CMake
+COPY install-cmake.sh /tmp/
+RUN if [ "${CMAKE_VERSION}" != "none" ]; then \
+        chmod +x /tmp/install-cmake.sh && /tmp/install-cmake.sh ${CMAKE_VERSION}; \
+    fi && \
+    rm -f /tmp/install-cmake.sh
+
 # Set Working Directory
 WORKDIR /opt
-
-# Install CMake
-COPY install-cmake.sh .
-RUN if [ "${CMAKE_VERSION}" != "none" ]; then \
-        chmod +x install-cmake.sh && install-cmake.sh ${CMAKE_VERSION}; \
-    fi && \
-    rm -f install-cmake.sh
 
 # Install ZED SDK
 RUN wget -q -O ZED_SDK_Linux_Ubuntu${UBUNTU_MAJOR}.run \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,10 +10,12 @@
         // "-v /tmp/.X11-unix:/tmp/.X11-unix" // Required for container to access display.
     ],
     "image": "ghcr.io/missourimrdt/autonomy-ubuntu20.04:latest",
+    // "image": "ghcr.io/missourimrdt/autonomy-ubuntu22.04:latest",
     // "image": "ghcr.io/missourimrdt/autonomy-jetpack5.1:latest",
     // "build": {
     //     "dockerfile": "Dockerfile_Ubuntu20"
-    //     //  "dockerfile": "Dockerfile_JetPack5"
+    //     "dockerfile": "Dockerfile_Ubuntu22"
+    //     "dockerfile": "Dockerfile_JetPack5"
     // },
     // Features to add to the dev container. More info: https://containers.dev/features.
     // "features": {},

--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@
   </div>
   <div>
     <a href="https://github.com/MissouriMRDT/Autonomy_Software/pkgs/container/autonomy-ubuntu20.04">
-      <img src="https://img.shields.io/badge/autonomy--ubuntu20.04-2023--08--15-orange" alt="ubuntu-pkg" />
+      <img src="https://img.shields.io/badge/Ubuntu_20.04-2023--08--16-orange" alt="ubuntu-pkg" />
+    </a>
+    <a href="https://github.com/MissouriMRDT/Autonomy_Software/pkgs/container/autonomy-ubuntu22.04">
+      <img src="https://img.shields.io/badge/Ubuntu_22.04-2023--08--16-orange" alt="ubuntu-pkg" />
     </a>
     <a href="https://github.com/MissouriMRDT/Autonomy_Software/pkgs/container/autonomy-jetpack5.1">
-      <img src="https://img.shields.io/badge/autonomy--jetpack5.1-2023--08--02-orange" alt="jetpack-pkg" />
+      <img src="https://img.shields.io/badge/JetPack_5.1-2023--08--16-orange" alt="jetpack-pkg" />
     </a>
   </div>
   <div>


### PR DESCRIPTION
### Problem
Whenever there is new release of JetPack or Ubuntu, it takes a long time for new versions of the `stereolabs/zed` docker images to be released.

### Fix
We have now switched to using the base docker image from the `stereolabs/zed` docker images and are manually installing the ZED SDK as well as all the packages we were already installing. This should allow for us to have more up-to-date images.

### Docker Images
_Note: The new images have been built and work as expected. I have pushed them and will assign the latest tag after this pull request is approved and merged._