### PR TITLE
Fix Project Warnings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -139,10 +139,10 @@
                 "doxdocgen.generic.useGitUserName": true,
                 // Todo Tree Extention Settings
                 "todo-tree.general.tags": [
-                    "FIXME",
-                    "TODO",
-                    "LEAD",
-                    "ISSUE NOTE"
+                    "FIXME:",
+                    "TODO:",
+                    "LEAD:",
+                    "ISSUE NOTE:"
                 ],
                 "todo-tree.highlights.customHighlight": {
                     "TODO": {

--- a/src/drivers/DriveBoard.cpp
+++ b/src/drivers/DriveBoard.cpp
@@ -79,7 +79,7 @@ std::vector<int> DriveBoard::CalculateMove(float fSpeed, float fAngle)
  * @author Eli Byrd (edbgkk@mst.edu)
  * @date 2023-06-18
  ******************************************************************************/
-void DriveBoard::SendDrive(int nLeftTarget, int nRightTarget) {}
+void DriveBoard::SendDrive(/*int nLeftTarget, int nRightTarget*/) {}
 
 /******************************************************************************
  * @brief Stop the drivetrain of the Rover.

--- a/src/drivers/DriveBoard.h
+++ b/src/drivers/DriveBoard.h
@@ -25,7 +25,7 @@ class DriveBoard
         ~DriveBoard();
 
         std::vector<int> CalculateMove(float fSpeed, float fAngle);
-        void SendDrive(int iLeftTarget, int iRightTarget);
+        void SendDrive(/*int iLeftTarget, int iRightTarget*/);
         void SendStop();
 };
 

--- a/src/drivers/MultimediaBoard.cpp
+++ b/src/drivers/MultimediaBoard.cpp
@@ -40,7 +40,7 @@ MultimediaBoard::~MultimediaBoard() {}
  * @author Eli Byrd (edbgkk@mst.edu)
  * @date 2023-06-20
  ******************************************************************************/
-void MultimediaBoard::SendLightingState(MultimediaBoardLightingState eState) {}
+void MultimediaBoard::SendLightingState(/*MultimediaBoardLightingState eState*/) {}
 
 /******************************************************************************
  * @brief Send a custom RGB value to the board.
@@ -51,4 +51,4 @@ void MultimediaBoard::SendLightingState(MultimediaBoardLightingState eState) {}
  * @author Eli Byrd (edbgkk@mst.edu)
  * @date 2023-06-20
  ******************************************************************************/
-void MultimediaBoard::SendRGB(RGB rgbVal) {}
+void MultimediaBoard::SendRGB(/*RGB rgbVal*/) {}

--- a/src/drivers/MultimediaBoard.h
+++ b/src/drivers/MultimediaBoard.h
@@ -52,8 +52,8 @@ class MultimediaBoard
         MultimediaBoard();
         ~MultimediaBoard();
 
-        void SendLightingState(MultimediaBoardLightingState eState);
-        void SendRGB(RGB);
+        void SendLightingState(/*MultimediaBoardLightingState eState*/);
+        void SendRGB(/*RGB rgbVal*/);
 };
 
 #endif    // MULTIMEDIABOARD_H


### PR DESCRIPTION
By removing unused parameters from functions we will not be hitting any warnings on build.

Note: This doesn't fix the warnings in the state machine. This will be fixed in a future Pull Request.