### PR TITLE
[BUG] Examples Runner

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,9 +21,8 @@
 // If not included, define empty run example function and set bRunExampleFlag
 // to false. If included, then define bRunExampleFlag as true.
 #ifndef CHECK_IF_EXAMPLE_INCLUDED
-#include "./util/ExampleChecker.h"
+static bool bRunExampleFlag = false;
 
-CHECK_IF_EXAMPLE_INCLUDED
 void RunExample() {}
 #else
 CHECK_IF_EXAMPLE_INCLUDED


### PR DESCRIPTION
This PR fixes a bug in main.cpp that would always execute the RunExample() function even if an example wasn't included.

Closes issue #105