### PR TITLE
Fix `make install` breaks during link to RoveComm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CP
 set(CPACK_GENERATOR "STGZ")
 
 ## Find RoveComm
-FetchContent_Declare(RoveComm_CPP                                                   # Custom Network Protocol (RoveComm)
+FetchContent_Declare(RoveComm_CPP                                                   # Custom Network Protocol (RoveComm C++)
         GIT_REPOSITORY https://github.com/MissouriMRDT/RoveComm_CPP.git             # Source Code URL
         GIT_TAG        608453f6b3e1a4445d281020d7dea568f7bf5e8d                     # Version 24.0.0
         GIT_SHALLOW    FALSE                                                        # Download only without history


### PR DESCRIPTION
- RoveComm Library was looking for a non existant header file from an older implementation of the library. missourimrdt/rovecomm_cpp@85ef67dab352652cb38a9ff8650e3aa5de31e7d0
- RoveComm Library was looking in wrong location for install instructions file. missourimrdt/rovecomm_cpp@608453f6b3e1a4445d281020d7dea568f7bf5e8d

Closes #112