### PR TITLE
Remove all warnings from application

### DIFF
--- a/src/states/AbortState.hpp
+++ b/src/states/AbortState.hpp
@@ -32,9 +32,17 @@ struct AbortState : sc::simple_state<AbortState, StateMachine>
 
         typedef mpl::list<sc::custom_reaction<Abort_RestartTransition>, sc::custom_reaction<Abort_ExitTransition>> reactions;
 
-        sc::result react(const Abort_RestartTransition& event) { return transit<IdleState>(); }
+        sc::result react(const Abort_RestartTransition& event)
+        {
+            (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+            return transit<IdleState>();
+        }
 
-        sc::result react(const Abort_ExitTransition& event) { return transit<IdleState>(); /* TODO: Exit the application */ }
+        sc::result react(const Abort_ExitTransition& event)
+        {
+            (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+            return transit<IdleState>();
+        }
 };
 
 /******************************************************************************

--- a/src/states/ApproachingGateState.hpp
+++ b/src/states/ApproachingGateState.hpp
@@ -35,11 +35,17 @@ struct ApproachingGateState : sc::simple_state<ApproachingGateState, StateMachin
                           sc::custom_reaction<ApproachingGate_ReachedMarkerTransition>>
             reactions;
 
-        sc::result react(const ApproachingGate_MarkerLostTransition& event) { return transit<SearchPatternState>(); }
+        sc::result react(const ApproachingGate_MarkerLostTransition& event) { 
+            (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+            return transit<SearchPatternState>(); }
 
-        sc::result react(const ApproachingGate_AbortTransition& event) { return transit<AbortState>(); }
+        sc::result react(const ApproachingGate_AbortTransition& event) { 
+            (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+            return transit<AbortState>(); }
 
-        sc::result react(const ApproachingGate_ReachedMarkerTransition& event) { return transit<IdleState>(); }
+        sc::result react(const ApproachingGate_ReachedMarkerTransition& event) {
+            (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+            return transit<IdleState>(); }
 };
 
 /******************************************************************************

--- a/src/states/ApproachingMarkerState.hpp
+++ b/src/states/ApproachingMarkerState.hpp
@@ -35,11 +35,23 @@ struct ApproachingMarkerState : sc::simple_state<ApproachingMarkerState, StateMa
                           sc::custom_reaction<ApproachingMarker_ReachedMarkerTransition>>
             reactions;
 
-        sc::result react(const ApproachingMarker_MarkerLostTransition& event) { return transit<SearchPatternState>(); }
+        sc::result react(const ApproachingMarker_MarkerLostTransition& event)
+        {
+            (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+            return transit<SearchPatternState>();
+        }
 
-        sc::result react(const ApproachingMarker_AbortTransition& event) { return transit<AbortState>(); }
+        sc::result react(const ApproachingMarker_AbortTransition& event)
+        {
+            (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+            return transit<AbortState>();
+        }
 
-        sc::result react(const ApproachingMarker_ReachedMarkerTransition& event) { return transit<IdleState>(); }
+        sc::result react(const ApproachingMarker_ReachedMarkerTransition& event)
+        {
+            (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+            return transit<IdleState>();
+        }
 };
 
 /******************************************************************************

--- a/src/states/AvoidanceState.hpp
+++ b/src/states/AvoidanceState.hpp
@@ -41,12 +41,16 @@ struct AvoidanceState : sc::simple_state<AvoidanceState, StateMachine>
             // If - Navigation
             //      return transit<NavigationState>();
 
+        (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+
             return transit<AbortState>();
         }
 
-        sc::result react(const Avoidance_AbortTransition& event) { return transit<AbortState>(); }
+        sc::result react(const Avoidance_AbortTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<AbortState>(); }
 
-        sc::result react(const Avoidance_StuckTransition& event) { return transit<StuckState>(); }
+        sc::result react(const Avoidance_StuckTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<StuckState>(); }
 };
 
 /******************************************************************************

--- a/src/states/IdleState.hpp
+++ b/src/states/IdleState.hpp
@@ -33,11 +33,14 @@ struct IdleState : sc::simple_state<IdleState, StateMachine>
         typedef mpl::list<sc::custom_reaction<Idle_AbortTransition>, sc::custom_reaction<Idle_NavigatingTransition>, sc::custom_reaction<Idle_ReverseTransition>>
             reactions;
 
-        sc::result react(const Idle_AbortTransition& event) { return transit<AbortState>(); }
+        sc::result react(const Idle_AbortTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<AbortState>(); }
 
-        sc::result react(const Idle_NavigatingTransition& event) { return transit<NavigationState>(); }
+        sc::result react(const Idle_NavigatingTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<NavigationState>(); }
 
-        sc::result react(const Idle_ReverseTransition& event) { return transit<ReverseState>(); }
+        sc::result react(const Idle_ReverseTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<ReverseState>(); }
 };
 
 /******************************************************************************

--- a/src/states/NavigationState.hpp
+++ b/src/states/NavigationState.hpp
@@ -38,11 +38,14 @@ struct NavigationState : sc::simple_state<NavigationState, StateMachine>
                           sc::custom_reaction<Navigation_ObstacleAvoidanceTransition>>
             reactions;
 
-        sc::result react(const Navigation_NewWaypointTransition& event) { return transit<NavigationState>(); }
+        sc::result react(const Navigation_NewWaypointTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<NavigationState>(); }
 
-        sc::result react(const Navigation_AbortTransition& event) { return transit<AbortState>(); }
+        sc::result react(const Navigation_AbortTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<AbortState>(); }
 
-        sc::result react(const Navigation_StuckTransition& event) { return transit<StuckState>(); }
+        sc::result react(const Navigation_StuckTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<StuckState>(); }
 
         sc::result react(const Navigation_ReachedGPSTransition& event)
         {
@@ -51,6 +54,8 @@ struct NavigationState : sc::simple_state<NavigationState, StateMachine>
 
             // If - ArUco Search
             //      return transit<SearchPatternState>();
+
+    (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
 
             return transit<AbortState>();
         }
@@ -63,10 +68,13 @@ struct NavigationState : sc::simple_state<NavigationState, StateMachine>
             // If - Gate
             //      return transit<ApproachingGateState>();
 
+        (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+
             return transit<AbortState>();
         }
 
-        sc::result react(const Navigation_ObstacleAvoidanceTransition& event) { return transit<AvoidanceState>(); }
+        sc::result react(const Navigation_ObstacleAvoidanceTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<AvoidanceState>(); }
 };
 
 /******************************************************************************

--- a/src/states/ReverseState.hpp
+++ b/src/states/ReverseState.hpp
@@ -54,12 +54,15 @@ struct ReverseState : sc::simple_state<ReverseState, StateMachine>
             // If - Approaching Gate
             //      return transit<ApproachingGateState>();
 
+(void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
             return transit<AbortState>();
         }
 
-        sc::result react(const Reverse_AbortTransition& event) { return transit<AbortState>(); }
+        sc::result react(const Reverse_AbortTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<AbortState>(); }
 
-        sc::result react(const Reverse_StuckTransition& event) { return transit<StuckState>(); }
+        sc::result react(const Reverse_StuckTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<StuckState>(); }
 };
 
 /******************************************************************************

--- a/src/states/SearchPatternState.hpp
+++ b/src/states/SearchPatternState.hpp
@@ -37,15 +37,23 @@ struct SearchPatternState : sc::simple_state<SearchPatternState, StateMachine>
                           sc::custom_reaction<SeachPattern_StuckTransition>>
             reactions;
 
-        sc::result react(const SeachPattern_GateSeenTransition& event) { return transit<ApproachingGateState>(); }
+        sc::result react(const SeachPattern_GateSeenTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<ApproachingGateState>(); }
 
-        sc::result react(const SeachPattern_ObstacleAvoidanceTransition& event) { return transit<AvoidanceState>(); }
+        sc::result react(const SeachPattern_ObstacleAvoidanceTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<AvoidanceState>(); }
 
-        sc::result react(const SeachPattern_MarkerSeenTransition& event) { return transit<ApproachingMarkerState>(); }
+        sc::result react(const SeachPattern_MarkerSeenTransition& event) { (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+        return transit<ApproachingMarkerState>(); }
 
-        sc::result react(const SeachPattern_AbortTransition& event) { return transit<AbortState>(); }
+        sc::result react(const SeachPattern_AbortTransition& event) {
+            (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+            return transit<AbortState>(); }
 
-        sc::result react(const SeachPattern_StuckTransition& event) { return transit<StuckState>(); }
+            sc::result react(const SeachPattern_StuckTransition& event)
+            {
+                (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+                return transit<StuckState>(); }
 };
 
 /******************************************************************************

--- a/src/states/StuckState.hpp
+++ b/src/states/StuckState.hpp
@@ -31,9 +31,17 @@ struct StuckState : sc::simple_state<StuckState, StateMachine>
 
         typedef mpl::list<sc::custom_reaction<Stuck_AbortTransition>, sc::custom_reaction<Stuck_ReverseTransition>> reactions;
 
-        sc::result react(const Stuck_AbortTransition& event) { return transit<AbortState>(); }
+        sc::result react(const Stuck_AbortTransition& event)
+        {
+            (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+            return transit<AbortState>();
+        }
 
-        sc::result react(const Stuck_ReverseTransition& event) { return transit<ReverseState>(); }
+        sc::result react(const Stuck_ReverseTransition& event)
+        {
+            (void) event;    // Will be removed in new implementation of State Machine that doesn't require boost.
+            return transit<ReverseState>();
+        }
 };
 
 /******************************************************************************


### PR DESCRIPTION
- Added a `(void)` call in front of unused state machine parameters that will eventually get removed with new implementation of the state machine.