### PR TITLE
Hotfix/jetson testing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,8 +28,8 @@
         "source=${localWorkspaceFolder}/data/models/zed,target=/usr/local/zed/resources,type=bind,consistency=delegated"
     ],
     // "image": "ghcr.io/missourimrdt/autonomy-jammy:latest",
-    // "image": "ghcr.io/missourimrdt/autonomy-focal:latest",
-    "image": "ghcr.io/missourimrdt/autonomy-jetpack:latest",
+    "image": "ghcr.io/missourimrdt/autonomy-focal:latest",
+    // "image": "ghcr.io/missourimrdt/autonomy-jetpack:latest",
     // "build": {
     //     // "dockerfile": "Dockerfile_Jammy"
     //     "dockerfile": "Dockerfile_Focal"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,9 @@
         "--name",
         "Autonomy_Software_devcontainer",
         // Add all available GPUs
-        "--gpus",
-        "all",
+        // "--gpus",
+        // "all",
+        "--runtime=nvidia",
         // Grants permission to the container to access USBs.
         "--privileged",
         "-v",
@@ -27,8 +28,8 @@
         "source=${localWorkspaceFolder}/data/models/zed,target=/usr/local/zed/resources,type=bind,consistency=delegated"
     ],
     // "image": "ghcr.io/missourimrdt/autonomy-jammy:latest",
-    "image": "ghcr.io/missourimrdt/autonomy-focal:latest",
-    // "image": "ghcr.io/missourimrdt/autonomy-jetpack:latest",
+    // "image": "ghcr.io/missourimrdt/autonomy-focal:latest",
+    "image": "ghcr.io/missourimrdt/autonomy-jetpack:latest",
     // "build": {
     //     // "dockerfile": "Dockerfile_Jammy"
     //     "dockerfile": "Dockerfile_Focal"

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ docs/*
 docs/Doxygen/*
 !docs/Doxygen/resources
 
+# Data. Ignore optimized models, but push base model.
+data/models/zed/.*
+
 ### MacOS Temp Files ###
 # Filesystem
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ find_package(OpenCV REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
 
 ## Find CUDA.
-find_package(CUDA 11.7 REQUIRED)
+find_package(CUDA 11.4 REQUIRED)
 message(STATUS "Found CUDA ${CUDA_VERSION_STRING} at ${CUDA_TOOLKIT_ROOT_DIR}")
 
 ## Find ZEDSDK. Add as system package to supress library warnings.
@@ -84,7 +84,7 @@ include_directories(SYSTEM ${ZED_INCLUDE_DIRS})
 link_directories(${ZED_LIBRARY_DIRS})
 
 ## Find CUDA. Must match ZEDSDK version. Add as system package to supress library warnings.
-find_package(CUDAToolkit ${ZED_CUDA_VERSION} EXACT REQUIRED)
+find_package(CUDAToolkit ${ZED_CUDA_VERSION} REQUIRED)
 include_directories(SYSTEM ${CUDA_INCLUDE_DIRS})
 link_directories(${CUDA_LIBRARY_DIRS})
 ## Determine if shared or static libraries will be used.

--- a/src/AutonomyConstants.h
+++ b/src/AutonomyConstants.h
@@ -41,7 +41,7 @@ namespace constants
     const sl::COORDINATE_SYSTEM ZED_COORD_SYSTEM = sl::COORDINATE_SYSTEM::LEFT_HANDED_Y_UP;    // Coordinate system to use for measurements.
     const sl::DEPTH_MODE ZED_DEPTH_MODE          = sl::DEPTH_MODE::NEURAL;                     // The measurement accuracy for depth. NEURAL is by far the best.
     const sl::VIEW ZED_RETRIEVE_VIEW             = sl::VIEW::LEFT;                             // The eye to retrieve regular and depth images from.
-    const bool ZED_SENSING_FILL                  = false;    // True provides a depth map with a Z value for every pixel (X, Y) in the left image. Slower.
+    const bool ZED_SENSING_FILL                  = false;    // True provides a depth map with a Z value for every pixel (X, Y) in the left image. Slower and worse.
     const float ZED_DEFAULT_MINIMUM_DISTANCE     = 0.2;      // Minimum distance in ZED_MEASURE_UNITS to report from depth measurement.
     const float ZED_DEFAULT_MAXIMUM_DISTANCE     = 40.0;     // Maximum distance in ZED_MEASURE_UNITS to report from depth measurement.
     const int ZED_DEPTH_STABILIZATION            = 1;    // This parameter controls a stabilization filter that reduces oscillations in depth map. In the range [0-100]
@@ -80,8 +80,8 @@ namespace constants
     const int ZED_MAINCAM_HORIZONTAL_FOV            = 110;         // The horizontal FOV of the camera. Useful for future calculations.
     const int ZED_MAINCAM_VERTICAL_FOV              = 70;          // The vertical FOV of the camera. Useful for future calculations.
     const bool ZED_MAINCAM_USE_GPU_MAT              = true;        // Whether or not to use CPU or GPU memory mats. GPU memory transfer/operations are faster.
-    const bool ZED_MAINCAM_USE_HALF_PRECISION_DEPTH = false;       // Whether of not to use float32 or unsigned short (16) for depth measure.
-    const int ZED_MAINCAM_FRAME_RETRIEVAL_THREADS   = 30;          // The number of threads allocated to the threadpool for performing frame copies to other threads.
+    const bool ZED_MAINCAM_USE_HALF_PRECISION_DEPTH = true;        // Whether of not to use float32 or unsigned short (16) for depth measure.
+    const int ZED_MAINCAM_FRAME_RETRIEVAL_THREADS   = 20;          // The number of threads allocated to the threadpool for performing frame copies to other threads.
     const int ZED_MAINCAN_SERIAL                    = 31237348;    // The serial number of the camera.
 
     // Left Side Cam.


### PR DESCRIPTION
Adjusted the CMakeLists to work for both building on the Jetson and on x86 hosts running the focal and jammy containers. Some other small tweaks were made to improve runtime execution speed.

TESTED:
11.4 is automatically used when compiling on Jetson
11.7 is automatically used when compiling on modern x86 host machines.