### PR TITLE
HOTFIX: Camera Recorder and General Bug Fixes

### DIFF
--- a/examples/vision/tagdetection/ArucoDetectionBasicCam.hpp
+++ b/examples/vision/tagdetection/ArucoDetectionBasicCam.hpp
@@ -40,7 +40,6 @@ void RunExample()
 
     // Declare mats to store images in.
     cv::Mat cvNormalFrame1;
-    cv::Mat cvPreProcessFrame1;
     cv::Mat cvDetectionsFrame1;
     // Declare vector to store tag detections in.
     std::vector<arucotag::ArucoTag> vTagDetections1;

--- a/src/AutonomyConstants.h
+++ b/src/AutonomyConstants.h
@@ -148,7 +148,7 @@ namespace constants
     const int BASICCAM_RIGHTCAM_HORIZONTAL_FOV          = 110;     // The horizontal FOV of the camera. Useful for future calculations.
     const int BASICCAM_RIGHTCAM_VERTICAL_FOV            = 70;      // The vertical FOV of the camera. Useful for future calculations.
     const int BASICCAM_RIGHTCAM_FRAME_RETRIEVAL_THREADS = 10;      // The number of threads allocated to the threadpool for performing frame copies to other threads.
-    const int BASICCAM_RIGHTCAM_INDEX                   = 3;       // The /dev/video index of the camera.
+    const int BASICCAM_RIGHTCAM_INDEX                   = 2;       // The /dev/video index of the camera.
     const PIXEL_FORMATS BASICCAM_RIGHTCAM_PIXELTYPE     = PIXEL_FORMATS::eBGR;    // The pixel layout of the camera.
     ///////////////////////////////////////////////////////////////////////////
 

--- a/src/AutonomyConstants.h
+++ b/src/AutonomyConstants.h
@@ -148,7 +148,7 @@ namespace constants
     const int BASICCAM_RIGHTCAM_HORIZONTAL_FOV          = 110;     // The horizontal FOV of the camera. Useful for future calculations.
     const int BASICCAM_RIGHTCAM_VERTICAL_FOV            = 70;      // The vertical FOV of the camera. Useful for future calculations.
     const int BASICCAM_RIGHTCAM_FRAME_RETRIEVAL_THREADS = 10;      // The number of threads allocated to the threadpool for performing frame copies to other threads.
-    const int BASICCAM_RIGHTCAM_INDEX                   = 1;       // The /dev/video index of the camera.
+    const int BASICCAM_RIGHTCAM_INDEX                   = 3;       // The /dev/video index of the camera.
     const PIXEL_FORMATS BASICCAM_RIGHTCAM_PIXELTYPE     = PIXEL_FORMATS::eBGR;    // The pixel layout of the camera.
     ///////////////////////////////////////////////////////////////////////////
 

--- a/src/handlers/RecordingHandler.cpp
+++ b/src/handlers/RecordingHandler.cpp
@@ -184,11 +184,6 @@ void RecordingHandler::UpdateRecordableCameras()
                                   pBasicCamera->GetCameraLocation());
                     }
                 }
-                else
-                {
-                    // Submit logger message.
-                    LOG_DEBUG(logging::g_qSharedLogger, "Not creating VideoWriter output directory {}: it already exists.", szFilePath.string());
-                }
 
                 // Construct the full output path.
                 std::filesystem::path szFullOutputPath = szFilePath / szFilenameWithExtension;
@@ -255,10 +250,6 @@ void RecordingHandler::UpdateRecordableCameras()
                                   pZEDCamera->GetCameraModel(),
                                   pZEDCamera->GetCameraSerial());
                     }
-                }
-                {
-                    // Submit logger message.
-                    LOG_DEBUG(logging::g_qSharedLogger, "Not creating VideoWriter output directory {}: it already exists.", szFilePath.string());
                 }
 
                 // Construct the full output path.

--- a/src/handlers/RecordingHandler.cpp
+++ b/src/handlers/RecordingHandler.cpp
@@ -187,7 +187,7 @@ void RecordingHandler::UpdateRecordableCameras()
                 else
                 {
                     // Submit logger message.
-                    LOG_ERROR(logging::g_qSharedLogger, "Unable to create VideoWriter output directory {}: it already exists.", szFilePath.string());
+                    LOG_DEBUG(logging::g_qSharedLogger, "Not creating VideoWriter output directory {}: it already exists.", szFilePath.string());
                 }
 
                 // Construct the full output path.
@@ -255,6 +255,10 @@ void RecordingHandler::UpdateRecordableCameras()
                                   pZEDCamera->GetCameraModel(),
                                   pZEDCamera->GetCameraSerial());
                     }
+                }
+                {
+                    // Submit logger message.
+                    LOG_DEBUG(logging::g_qSharedLogger, "Not creating VideoWriter output directory {}: it already exists.", szFilePath.string());
                 }
 
                 // Construct the full output path.

--- a/src/handlers/RecordingHandler.cpp
+++ b/src/handlers/RecordingHandler.cpp
@@ -168,8 +168,8 @@ void RecordingHandler::UpdateRecordableCameras()
                 std::filesystem::path szFilePath;
                 std::filesystem::path szFilenameWithExtension;
                 szFilePath = constants::LOGGING_OUTPUT_PATH_ABSOLUTE;                    // Main location for all recordings.
-                szFilePath += logging::g_szProgramStartTimeString + "/cameras/";         // Folder for each program run.
-                szFilenameWithExtension = pBasicCamera->GetCameraLocation() + ".mp4";    // Folder for each camera index or name.
+                szFilePath += logging::g_szProgramStartTimeString + "/cameras";          // Folder for each program run.
+                szFilenameWithExtension = pBasicCamera->GetCameraLocation() + ".mkv";    // Folder for each camera index or name.
 
                 // Check if directory exists.
                 if (!std::filesystem::exists(szFilePath))
@@ -195,7 +195,7 @@ void RecordingHandler::UpdateRecordableCameras()
 
                 // Open writer.
                 bool bWriterOpened = m_vCameraWriters[nCamera - 1].open(szFullOutputPath.string(),
-                                                                        cv::VideoWriter::fourcc('m', 'p', '4', 'v'),
+                                                                        cv::VideoWriter::fourcc('H', '2', '6', '4'),
                                                                         constants::RECORDER_FPS,
                                                                         pBasicCamera->GetPropResolution());
 
@@ -238,9 +238,9 @@ void RecordingHandler::UpdateRecordableCameras()
                 std::filesystem::path szFilePath;
                 std::filesystem::path szFilenameWithExtension;
                 szFilePath = constants::LOGGING_OUTPUT_PATH_ABSOLUTE;                                               // Main location for all recordings.
-                szFilePath += logging::g_szProgramStartTimeString + "/cameras/";                                    // Folder for each program run.
+                szFilePath += logging::g_szProgramStartTimeString + "/cameras";                                     // Folder for each program run.
                 szFilenameWithExtension =
-                    pZEDCamera->GetCameraModel() + "_" + std::to_string(pZEDCamera->GetCameraSerial()) + ".mp4";    // Folder for each camera index or name.
+                    pZEDCamera->GetCameraModel() + "_" + std::to_string(pZEDCamera->GetCameraSerial()) + ".mkv";    // Folder for each camera index or name.
 
                 // Check if directory exists.
                 if (!std::filesystem::exists(szFilePath))
@@ -262,7 +262,7 @@ void RecordingHandler::UpdateRecordableCameras()
 
                 // Open writer.
                 bool bWriterOpened = m_vCameraWriters[nCamera + nIndexOffset].open(szFullOutputPath,
-                                                                                   cv::VideoWriter::fourcc('m', 'p', '4', 'v'),
+                                                                                   cv::VideoWriter::fourcc('H', '2', '6', '4'),
                                                                                    constants::RECORDER_FPS,
                                                                                    pZEDCamera->GetPropResolution());
 
@@ -420,7 +420,7 @@ void RecordingHandler::UpdateRecordableTagDetectors()
                 std::filesystem::path szFilenameWithExtension;
                 szFilePath = constants::LOGGING_OUTPUT_PATH_ABSOLUTE;                  // Main location for all recordings.
                 szFilePath += logging::g_szProgramStartTimeString + "/tagdetector";    // Folder for each program run.
-                szFilenameWithExtension = pTagDetector->GetCameraName() + ".mp4";      // Folder for each camera index or name.
+                szFilenameWithExtension = pTagDetector->GetCameraName() + ".mkv";      // Folder for each camera index or name.
 
                 // Check if directory exists.
                 if (!std::filesystem::exists(szFilePath))
@@ -446,7 +446,7 @@ void RecordingHandler::UpdateRecordableTagDetectors()
 
                 // Open writer.
                 bool bWriterOpened = m_vCameraWriters[nDetector - 1].open(szFullOutputPath.string(),
-                                                                          cv::VideoWriter::fourcc('m', 'p', '4', 'v'),
+                                                                          cv::VideoWriter::fourcc('H', '2', '6', '4'),
                                                                           constants::RECORDER_FPS,
                                                                           pTagDetector->GetProcessFrameResolution());
 

--- a/src/handlers/RecordingHandler.cpp
+++ b/src/handlers/RecordingHandler.cpp
@@ -430,11 +430,6 @@ void RecordingHandler::UpdateRecordableTagDetectors()
                                   pTagDetector->GetCameraName());
                     }
                 }
-                else
-                {
-                    // Submit logger message.
-                    LOG_ERROR(logging::g_qSharedLogger, "Unable to create VideoWriter output directory {}: it already exists.", szFilePath.string());
-                }
 
                 // Construct the full output path.
                 std::filesystem::path szFullOutputPath = szFilePath / szFilenameWithExtension;

--- a/src/handlers/TagDetectionHandler.cpp
+++ b/src/handlers/TagDetectionHandler.cpp
@@ -122,6 +122,10 @@ void TagDetectionHandler::StartRecording()
  ******************************************************************************/
 void TagDetectionHandler::StopAllDetectors()
 {
+    // Stop recording handler.
+    m_pRecordingHandler->RequestStop();
+    m_pRecordingHandler->Join();
+
     // Stop ZED maincam detector.
     m_pTagDetectorMainCam->RequestStop();
     m_pTagDetectorMainCam->Join();

--- a/src/interfaces/AutonomyThread.hpp
+++ b/src/interfaces/AutonomyThread.hpp
@@ -602,13 +602,13 @@ class AutonomyThread
                         std::this_thread::sleep_for(std::chrono::microseconds(nSleepTime));
                     }
                 }
-            }
 
-            // Check if thread state needs to be updated.
-            if (m_eThreadState != eRunning && m_eThreadState != eStopping)
-            {
-                // Update thread state to running.
-                m_eThreadState = eRunning;
+                // Check if thread state needs to be updated.
+                if (m_eThreadState != eRunning && m_eThreadState != eStopping)
+                {
+                    // Update thread state to running.
+                    m_eThreadState = eRunning;
+                }
             }
         }
 };

--- a/src/interfaces/Camera.hpp
+++ b/src/interfaces/Camera.hpp
@@ -132,7 +132,7 @@ class Camera
          * @author clayjay3 (claytonraycowen@gmail.com)
          * @date 2023-12-26
          ******************************************************************************/
-        bool GetEnableRecordingFlag() const { return m_bEnableRecordingFlag.load(); }
+        bool GetEnableRecordingFlag() const { return m_bEnableRecordingFlag; }
 
         /******************************************************************************
          * @brief Accessor for the Frame I P S private member.
@@ -152,7 +152,7 @@ class Camera
          * @author clayjay3 (claytonraycowen@gmail.com)
          * @date 2023-12-26
          ******************************************************************************/
-        void SetEnableRecordingFlag(const bool bEnableRecordingFlag) { m_bEnableRecordingFlag.store(bEnableRecordingFlag); }
+        void SetEnableRecordingFlag(const bool bEnableRecordingFlag) { m_bEnableRecordingFlag = bEnableRecordingFlag; }
 
     protected:
         // Declare protected methods and member variables.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <thread>
 
 #include "./AutonomyGlobals.h"
 #include "./AutonomyLogging.h"
@@ -128,7 +129,7 @@ int main()
     }
 
     // Submit logger message that program is done cleaning up and is now exiting.
-    LOG_INFO(logging::g_qSharedLogger, "Exiting...");
+    LOG_INFO(logging::g_qSharedLogger, "Clean up finished. Exiting...");
 
     // Successful exit.
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,9 +108,32 @@ int main()
 
         // TODO: Initialize RoveComm.
 
-        // Loop until user sends sigkill or sigterm.
+        /*
+            This while loop is the main periodic loop for the Autonomy_Software program.
+            Loop until user sends sigkill or sigterm.
+        */
         while (!bMainStop)
-        {}
+        {
+            // No need to loop as fast as possible. Sleep...
+            // Only run this main thread once every 20ms.
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+            // Get Camera and Tag detector pointers .
+            BasicCam* pLeftCam          = globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadLeftArucoEye);
+            BasicCam* pRightCam         = globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadRightArucoEye);
+            TagDetector* pLeftDetector  = globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::eHeadLeftArucoEye);
+            TagDetector* pRightDetector = globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::eHeadRightArucoEye);
+            // Create a string to append FPS values to.
+            std::string szThreadsFPS = "";
+            // Get FPS of all cameras and detectors and construct the info into a string.
+            szThreadsFPS += "--------[ Threads FPS ]--------\n";
+            szThreadsFPS += "LeftCam FPS: " + std::to_string(pLeftCam->GetIPS().GetExactIPS()) + "\n";
+            szThreadsFPS += "RightCam FPS: " + std::to_string(pRightCam->GetIPS().GetExactIPS()) + "\n";
+            szThreadsFPS += "LeftDetector FPS: " + std::to_string(pLeftDetector->GetIPS().GetExactIPS()) + "\n";
+            szThreadsFPS += "RightDetector GPS: " + std::to_string(pRightDetector->GetIPS().GetExactIPS()) + "\n";
+            // Submit logger message.
+            LOG_INFO(logging::g_qConsoleLogger, "{}", szThreadsFPS);
+        }
 
         /////////////////////////////////////////
         // Cleanup.
@@ -120,12 +143,12 @@ int main()
         globals::g_pCameraHandler->StopAllCameras();
 
         // Delete dynamically allocated objects.
-        delete globals::g_pCameraHandler;
         delete globals::g_pTagDetectionHandler;
+        delete globals::g_pCameraHandler;
 
         // Set dangling pointers to null.
-        globals::g_pCameraHandler       = nullptr;
         globals::g_pTagDetectionHandler = nullptr;
+        globals::g_pCameraHandler       = nullptr;
     }
 
     // Submit logger message that program is done cleaning up and is now exiting.

--- a/src/vision/aruco/TagDetector.cpp
+++ b/src/vision/aruco/TagDetector.cpp
@@ -151,7 +151,7 @@ void TagDetector::ThreadedContinuousCode()
 
             // Submit logger message.
             LOG_CRITICAL(logging::g_qSharedLogger,
-                         "Camera start was attempted for ZED camera with serial number {}, but camera never properly opened or it has been closed/rebooted!",
+                         "TagDetector start was attempted for ZED camera with serial number {}, but camera never properly opened or it has been closed/rebooted!",
                          dynamic_cast<ZEDCam*>(m_pCamera)->GetCameraSerial());
         }
     }
@@ -167,7 +167,7 @@ void TagDetector::ThreadedContinuousCode()
 
             // Submit logger message.
             LOG_CRITICAL(logging::g_qSharedLogger,
-                         "Camera start was attempted for BasicCam at {}, but camera never properly opened or it has become disconnected!",
+                         "TagDetector start was attempted for BasicCam at {}, but camera never properly opened or it has become disconnected!",
                          dynamic_cast<BasicCam*>(m_pCamera)->GetCameraLocation());
         }
     }

--- a/src/vision/aruco/TagDetector.cpp
+++ b/src/vision/aruco/TagDetector.cpp
@@ -597,7 +597,7 @@ void TagDetector::UpdateDetectedTags(std::vector<tensorflowtag::TensorflowTag>& 
  ******************************************************************************/
 void TagDetector::SetEnableRecordingFlag(const bool bEnableRecordingFlag)
 {
-    m_bEnableRecordingFlag.store(bEnableRecordingFlag);
+    m_bEnableRecordingFlag = bEnableRecordingFlag;
 }
 
 /******************************************************************************
@@ -629,7 +629,7 @@ bool TagDetector::GetIsReady()
     bool bDetectorIsReady = false;
 
     // Check if this detectors thread is currently running.
-    if (this->GetThreadsAreRunning())
+    if (this->GetThreadState() == eRunning)
     {
         // Check if using ZEDCam or BasicCam.
         if (m_bUsingZedCamera)
@@ -667,7 +667,7 @@ bool TagDetector::GetIsReady()
  ******************************************************************************/
 bool TagDetector::GetEnableRecordingFlag() const
 {
-    return m_bEnableRecordingFlag.load();
+    return m_bEnableRecordingFlag;
 }
 
 /******************************************************************************

--- a/src/vision/aruco/TagDetector.cpp
+++ b/src/vision/aruco/TagDetector.cpp
@@ -39,12 +39,13 @@ TagDetector::TagDetector(BasicCam* pBasicCam,
                          const bool bUsingGpuMats)
 {
     // Initialize member variables.
-    m_pCamera                          = dynamic_cast<BasicCam*>(pBasicCam);
+    m_pCamera                          = pBasicCam;
     m_bUsingZedCamera                  = false;    // Toggle ZED functions off.
     m_nNumDetectedTagsRetrievalThreads = nNumDetectedTagsRetrievalThreads;
     m_bUsingGpuMats                    = bUsingGpuMats;
-    m_IPS                              = IPS();
+    m_szCameraName                     = dynamic_cast<BasicCam*>(pBasicCam)->GetCameraLocation();
     m_bEnableRecordingFlag             = bEnableRecordingFlag;
+    m_IPS                              = IPS();
 
     // Setup aruco detector params.
     m_cvArucoDetectionParams                               = cv::aruco::DetectorParameters();
@@ -86,11 +87,13 @@ TagDetector::TagDetector(ZEDCam* pZEDCam,
                          const bool bUsingGpuMats)
 {
     // Initialize member variables.
-    m_pCamera                          = dynamic_cast<ZEDCam*>(pZEDCam);
+    m_pCamera                          = pZEDCam;
     m_bUsingZedCamera                  = true;    // Toggle ZED functions off.
     m_nNumDetectedTagsRetrievalThreads = nNumDetectedTagsRetrievalThreads;
     m_bUsingGpuMats                    = bUsingGpuMats;
+    m_szCameraName                     = dynamic_cast<ZEDCam*>(pZEDCam)->GetCameraModel() + "_" + std::to_string(dynamic_cast<ZEDCam*>(pZEDCam)->GetCameraSerial());
     m_bEnableRecordingFlag             = bEnableRecordingFlag;
+    m_IPS                              = IPS();
 
     // Setup aruco detector params.
     m_cvArucoDetectionParams                               = cv::aruco::DetectorParameters();
@@ -102,6 +105,23 @@ TagDetector::TagDetector(ZEDCam* pZEDCam,
     // Get aruco dictionary and initialize aruco detector.
     m_cvTagDictionary = cv::aruco::getPredefinedDictionary(constants::ARUCO_DICTIONARY);
     m_cvArucoDetector = cv::aruco::ArucoDetector(m_cvTagDictionary, m_cvArucoDetectionParams);
+}
+
+/******************************************************************************
+ * @brief Destroy the Tag Detector:: Tag Detector object.
+ *
+ *
+ * @author clayjay3 (claytonraycowen@gmail.com)
+ * @date 2024-01-09
+ ******************************************************************************/
+TagDetector::~TagDetector()
+{
+    // Stop threaded code.
+    this->RequestStop();
+    this->Join();
+
+    // Submit logger message.
+    LOG_DEBUG(logging::g_qSharedLogger, "TagDetector for camera {} had been successfully stopped.", this->GetCameraName());
 }
 
 /******************************************************************************
@@ -680,24 +700,7 @@ bool TagDetector::GetEnableRecordingFlag() const
  ******************************************************************************/
 std::string TagDetector::GetCameraName()
 {
-    // Create instance variables.
-    std::string szCameraName;
-
-    // Check if using a ZED camera.
-    if (m_bUsingZedCamera)
-    {
-        // Concatenate camera model name and serial number.
-        szCameraName = dynamic_cast<ZEDCam*>(m_pCamera)->GetCameraModel() + "_";
-        szCameraName += dynamic_cast<ZEDCam*>(m_pCamera)->GetCameraSerial();
-    }
-    else
-    {
-        // Concatenate camera path or index.
-        szCameraName = dynamic_cast<BasicCam*>(m_pCamera)->GetCameraLocation();
-    }
-
-    // Return camera name.
-    return szCameraName;
+    return m_szCameraName;
 }
 
 /******************************************************************************

--- a/src/vision/aruco/TagDetector.cpp
+++ b/src/vision/aruco/TagDetector.cpp
@@ -57,6 +57,9 @@ TagDetector::TagDetector(BasicCam* pBasicCam,
     // Get aruco dictionary and initialize aruco detector.
     m_cvTagDictionary = cv::aruco::getPredefinedDictionary(constants::ARUCO_DICTIONARY);
     m_cvArucoDetector = cv::aruco::ArucoDetector(m_cvTagDictionary, m_cvArucoDetectionParams);
+
+    // Submit logger message.
+    LOG_DEBUG(logging::g_qSharedLogger, "TagDetector created for camera at path/index: {}", m_szCameraName);
 }
 
 /******************************************************************************
@@ -105,6 +108,9 @@ TagDetector::TagDetector(ZEDCam* pZEDCam,
     // Get aruco dictionary and initialize aruco detector.
     m_cvTagDictionary = cv::aruco::getPredefinedDictionary(constants::ARUCO_DICTIONARY);
     m_cvArucoDetector = cv::aruco::ArucoDetector(m_cvTagDictionary, m_cvArucoDetectionParams);
+
+    // Submit logger message.
+    LOG_DEBUG(logging::g_qSharedLogger, "TagDetector created for camera: {}", m_szCameraName);
 }
 
 /******************************************************************************

--- a/src/vision/aruco/TagDetector.h
+++ b/src/vision/aruco/TagDetector.h
@@ -61,6 +61,7 @@ class TagDetector : public AutonomyThread<void>
                     const bool bEnableRecordingFlag               = false,
                     const int nNumDetectedTagsRetrievalThreads    = 5,
                     const bool bUsingGpuMats                      = false);
+        ~TagDetector();
         std::future<bool> RequestDetectionOverlayFrame(cv::Mat& cvFrame);
         std::future<bool> RequestDetectedArucoTags(std::vector<arucotag::ArucoTag>& vArucoTags);
         std::future<bool> RequestDetectedTensorflowTags(std::vector<tensorflowtag::TensorflowTag>& vTensorflowTags);
@@ -93,8 +94,9 @@ class TagDetector : public AutonomyThread<void>
         bool m_bUsingZedCamera;
         bool m_bUsingGpuMats;
         int m_nNumDetectedTagsRetrievalThreads;
-        IPS m_IPS;
+        std::string m_szCameraName;
         std::atomic_bool m_bEnableRecordingFlag;
+        IPS m_IPS;
 
         // Detected tags storage.
 

--- a/src/vision/cameras/ZEDCam.cpp
+++ b/src/vision/cameras/ZEDCam.cpp
@@ -164,10 +164,7 @@ ZEDCam::ZEDCam(const int nPropResolutionX,
     if (m_slCamera.isOpened())
     {
         // Submit logger message.
-        LOG_DEBUG(logging::g_qSharedLogger,
-                  "{} stereo camera with serial number {} has been successfully opened.",
-                  this->GetCameraModel(),
-                  m_slCamera.getCameraInformation().serial_number);
+        LOG_DEBUG(logging::g_qSharedLogger, "{} stereo camera with serial number {} has been successfully opened.", this->GetCameraModel(), m_unCameraSerialNumber);
     }
     else
     {
@@ -175,7 +172,7 @@ ZEDCam::ZEDCam(const int nPropResolutionX,
         LOG_ERROR(logging::g_qSharedLogger,
                   "Unable to open stereo camera {} ({})! sl::ERROR_CODE is: {}",
                   sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                  m_slCamera.getCameraInformation().serial_number,
+                  m_unCameraSerialNumber,
                   sl::toString(slReturnCode).get());
     }
 }
@@ -242,7 +239,7 @@ void ZEDCam::ThreadedContinuousCode()
                 LOG_WARNING(logging::g_qSharedLogger,
                             "Unable to retrieve new frame image for stereo camera {} ({})! sl::ERROR_CODE is: {}",
                             sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                            m_slCamera.getCameraInformation().serial_number,
+                            m_unCameraSerialNumber,
                             sl::toString(slReturnCode).get());
             }
 
@@ -255,7 +252,7 @@ void ZEDCam::ThreadedContinuousCode()
                 LOG_WARNING(logging::g_qSharedLogger,
                             "Unable to retrieve new depth measure for stereo camera {} ({})! sl::ERROR_CODE is: {}",
                             sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                            m_slCamera.getCameraInformation().serial_number,
+                            m_unCameraSerialNumber,
                             sl::toString(slReturnCode).get());
             }
 
@@ -268,7 +265,7 @@ void ZEDCam::ThreadedContinuousCode()
                 LOG_WARNING(logging::g_qSharedLogger,
                             "Unable to retrieve new depth image for stereo camera {} ({})! sl::ERROR_CODE is: {}",
                             sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                            m_slCamera.getCameraInformation().serial_number,
+                            m_unCameraSerialNumber,
                             sl::toString(slReturnCode).get());
             }
 
@@ -281,7 +278,7 @@ void ZEDCam::ThreadedContinuousCode()
                 LOG_WARNING(logging::g_qSharedLogger,
                             "Unable to retrieve new point cloud for stereo camera {} ({})! sl::ERROR_CODE is: {}",
                             sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                            m_slCamera.getCameraInformation().serial_number,
+                            m_unCameraSerialNumber,
                             sl::toString(slReturnCode).get());
             }
 
@@ -297,7 +294,7 @@ void ZEDCam::ThreadedContinuousCode()
                     LOG_WARNING(logging::g_qSharedLogger,
                                 "Unable to retrieve new positional tracking pose for stereo camera {} ({})! sl::POSITIONAL_TRACKING_STATE is: {}",
                                 sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                                m_slCamera.getCameraInformation().serial_number,
+                                m_unCameraSerialNumber,
                                 sl::toString(slPoseTrackReturnCode).get());
                 }
             }
@@ -313,7 +310,7 @@ void ZEDCam::ThreadedContinuousCode()
                     LOG_WARNING(logging::g_qSharedLogger,
                                 "Unable to retrieve new object data for stereo camera {} ({})! sl::ERROR_CODE is: {}",
                                 sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                                m_slCamera.getCameraInformation().serial_number,
+                                m_unCameraSerialNumber,
                                 sl::toString(slReturnCode).get());
                 }
 
@@ -329,7 +326,7 @@ void ZEDCam::ThreadedContinuousCode()
                         LOG_WARNING(logging::g_qSharedLogger,
                                     "Unable to retrieve new batched object data for stereo camera {} ({})! sl::ERROR_CODE is: {}",
                                     sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                                    m_slCamera.getCameraInformation().serial_number,
+                                    m_unCameraSerialNumber,
                                     sl::toString(slReturnCode).get());
                     }
                 }
@@ -349,7 +346,7 @@ void ZEDCam::ThreadedContinuousCode()
             LOG_ERROR(logging::g_qSharedLogger,
                       "Unable to update stereo camera {} ({}) frames, measurements, and sensors! sl::ERROR_CODE is: {}",
                       sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                      m_slCamera.getCameraInformation().serial_number,
+                      m_unCameraSerialNumber,
                       sl::toString(slReturnCode).get());
         }
 
@@ -824,7 +821,7 @@ sl::ERROR_CODE ZEDCam::TrackCustomBoxObjects(std::vector<ZedObjectData>& vCustom
         LOG_WARNING(logging::g_qSharedLogger,
                     "Failed to ingest new objects for camera {} ({})! sl::ERROR_CODE is: {}",
                     sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                    m_slCamera.getCameraInformation().serial_number,
+                    m_unCameraSerialNumber,
                     sl::toString(slReturnCode).get());
     }
 
@@ -845,7 +842,7 @@ sl::ERROR_CODE ZEDCam::RebootCamera()
     // Acquire write lock.
     std::unique_lock<std::shared_mutex> lkSharedLock(m_muCameraMutex);
     // Reboot this camera and return the status code.
-    return sl::Camera::reboot(m_slCamera.getCameraInformation().serial_number);
+    return sl::Camera::reboot(m_unCameraSerialNumber);
 }
 
 /******************************************************************************
@@ -872,7 +869,7 @@ sl::ERROR_CODE ZEDCam::EnablePositionalTracking()
         LOG_ERROR(logging::g_qSharedLogger,
                   "Failed to enabled positional tracking for camera {} ({})! sl::ERROR_CODE is: {}",
                   sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                  m_slCamera.getCameraInformation().serial_number,
+                  m_unCameraSerialNumber,
                   sl::toString(slReturnCode).get());
     }
 
@@ -981,7 +978,7 @@ sl::ERROR_CODE ZEDCam::EnableSpatialMapping(const int nTimeoutSeconds)
             LOG_ERROR(logging::g_qSharedLogger,
                       "Failed to enabled spatial mapping for camera {} ({})! sl::ERROR_CODE is: {}",
                       sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                      m_slCamera.getCameraInformation().serial_number,
+                      m_unCameraSerialNumber,
                       sl::toString(slReturnCode).get());
         }
     }
@@ -991,7 +988,7 @@ sl::ERROR_CODE ZEDCam::EnableSpatialMapping(const int nTimeoutSeconds)
         LOG_ERROR(logging::g_qSharedLogger,
                   "Failed to enabled spatial mapping for camera {} ({}) because positional tracking could not be enabled! sl::ERROR_CODE is: {}",
                   sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                  m_slCamera.getCameraInformation().serial_number,
+                  m_unCameraSerialNumber,
                   sl::toString(slReturnCode).get());
     }
 
@@ -1043,7 +1040,7 @@ sl::ERROR_CODE ZEDCam::EnableObjectDetection(const bool bEnableBatching)
         LOG_ERROR(logging::g_qSharedLogger,
                   "Failed to enabled object detection for camera {} ({})! sl::ERROR_CODE is: {}",
                   sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
-                  m_slCamera.getCameraInformation().serial_number,
+                  m_unCameraSerialNumber,
                   sl::toString(slReturnCode).get());
     }
 
@@ -1145,7 +1142,7 @@ std::string ZEDCam::GetCameraModel()
 unsigned int ZEDCam::GetCameraSerial()
 {
     // Return connected camera serial number.
-    return m_slCamera.getCameraInformation().serial_number;
+    return m_unCameraSerialNumber;
 }
 
 /******************************************************************************


### PR DESCRIPTION
# Bugs fixes:
- Improvements to logging file structure and output.
- Changed VideoWriter output from .MP4 to .MKV. This should reduce filesize and help with preventing loss of video logging during a crash or shutdown.
- The TagDetectionHandler::StopAllDetectors() method now also shuts down the RecordingHandler for the tag detectors. (Just like the CameraHandler::StopAllCameras() method)
- Fixed an issue with the TagDetector class causing the program to segfault if the cameras were previously started, but are now shutdown.

# Improvements:
- Reorganized AutonomyThread.hpp and added more comprehensive thread state tracking instead of just a simple running/not running boolean.
- Added Ctrl+C interruption handling for graceful shutdowns and cleanup actions.
- main.cpp now has an official while loop to keep the program running until a SIGINT.
- main.cpp while loop prints the FPS of some of the cameras and tag detectors.