### PR TITLE
AutonomyThread IPS Inaccurate

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,7 +6,7 @@
     
 - Download and install Visual Studio Code from [here](https://code.visualstudio.com/download)
 - Download and install git-scm from [here](https://git-scm.com/downloads)
-- Download and install Docker from [here](https://docs.docker.com/get-docker/)
+- Download and install Docker from [here](https://docs.docker.com/engine/install/) (NOTE: Only install Docker Desktop if you are on Windows! Only install Docker Engine for other OSs)
 
 (Optional) Needed for container GPU support.
     - Download and install NVIDIA Container Toolkit from [here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) This is only applicable if your machine has a GPU with CUDA. Windows users should integrate WSL (Windows Subsystem for Linux) into their Docker install. [Medium](https://medium.com/htc-research-engineering-blog/nvidia-docker-on-wsl2-f891dfe34ab) has an okay guide.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,13 +126,13 @@ int main()
             std::string szMainInfo = "";
             // Get FPS of all cameras and detectors and construct the info into a string.
             szMainInfo += "--------[ Threads FPS ]--------\n";
-            szMainInfo += "MainCam FPS: " + std::to_string(pMainCam->GetIPS().GetExactIPS()) + "\n";
-            szMainInfo += "LeftCam FPS: " + std::to_string(pLeftCam->GetIPS().GetExactIPS()) + "\n";
-            szMainInfo += "RightCam FPS: " + std::to_string(pRightCam->GetIPS().GetExactIPS()) + "\n";
-            szMainInfo += "MainDetector FPS: " + std::to_string(pMainDetector->GetIPS().GetExactIPS()) + "\n";
-            szMainInfo += "LeftDetector FPS: " + std::to_string(pLeftDetector->GetIPS().GetExactIPS()) + "\n";
-            szMainInfo += "RightDetector FPS: " + std::to_string(pRightDetector->GetIPS().GetExactIPS()) + "\n";
-            szMainInfo += "\nStateMachine FPS:" + std::to_string(globals::g_pStateMachineHandler->GetIPS().GetExactIPS()) + "\n";
+            szMainInfo += "MainCam FPS: " + std::to_string(pMainCam->GetIPS().GetAverageIPS()) + "\n";
+            szMainInfo += "LeftCam FPS: " + std::to_string(pLeftCam->GetIPS().GetAverageIPS()) + "\n";
+            szMainInfo += "RightCam FPS: " + std::to_string(pRightCam->GetIPS().GetAverageIPS()) + "\n";
+            szMainInfo += "MainDetector FPS: " + std::to_string(pMainDetector->GetIPS().GetAverageIPS()) + "\n";
+            szMainInfo += "LeftDetector FPS: " + std::to_string(pLeftDetector->GetIPS().GetAverageIPS()) + "\n";
+            szMainInfo += "RightDetector FPS: " + std::to_string(pRightDetector->GetIPS().GetAverageIPS()) + "\n";
+            szMainInfo += "\nStateMachine FPS:" + std::to_string(globals::g_pStateMachineHandler->GetIPS().GetAverageIPS()) + "\n";
             szMainInfo += "\n--------[ State Machine Info ]--------\n";
             szMainInfo += "Current State: " + statemachine::StateToString(globals::g_pStateMachineHandler->GetCurrentState()) + "\n";
             // Submit logger message.

--- a/src/vision/aruco/TagDetector.cpp
+++ b/src/vision/aruco/TagDetector.cpp
@@ -260,8 +260,6 @@ void TagDetector::ThreadedContinuousCode()
         // Merge the newly detected tags with the pre-existing detected tags
         this->UpdateDetectedTags(vNewlyDetectedTags);
 
-        // Call FPS tick.
-        m_IPS.Tick();
         /////////////////////////////////////////////////////////////////////////////////////
 
         // Acquire a shared_lock on the detected tags copy queue.
@@ -624,20 +622,6 @@ void TagDetector::UpdateDetectedTags(std::vector<tensorflowtag::TensorflowTag>& 
 void TagDetector::SetEnableRecordingFlag(const bool bEnableRecordingFlag)
 {
     m_bEnableRecordingFlag = bEnableRecordingFlag;
-}
-
-/******************************************************************************
- * @brief Accessor for the Frame I P S private member.
- *
- * @return IPS& - The detector objects iteration per second counter.
- *
- * @author clayjay3 (claytonraycowen@gmail.com)
- * @date 2023-10-10
- ******************************************************************************/
-IPS& TagDetector::GetIPS()
-{
-    // Return Iterations Per Second counter.
-    return m_IPS;
 }
 
 /******************************************************************************

--- a/src/vision/aruco/TagDetector.h
+++ b/src/vision/aruco/TagDetector.h
@@ -69,7 +69,6 @@ class TagDetector : public AutonomyThread<void>
         std::future<bool> RequestDetectedArucoTags(std::vector<arucotag::ArucoTag>& vArucoTags);
         std::future<bool> RequestDetectedTensorflowTags(std::vector<tensorflowtag::TensorflowTag>& vTensorflowTags);
         void SetEnableRecordingFlag(const bool bEnableRecordingFlag);
-        IPS& GetIPS();
         bool GetIsReady();
         bool GetEnableRecordingFlag() const;
         std::string GetCameraName();
@@ -99,7 +98,6 @@ class TagDetector : public AutonomyThread<void>
         int m_nNumDetectedTagsRetrievalThreads;
         std::string m_szCameraName;
         std::atomic_bool m_bEnableRecordingFlag;
-        IPS m_IPS;
 
         // Detected tags storage.
 

--- a/src/vision/cameras/BasicCam.cpp
+++ b/src/vision/cameras/BasicCam.cpp
@@ -169,9 +169,6 @@ void BasicCam::ThreadedContinuousCode()
         {
             // Resize the frame.
             cv::resize(m_cvFrame, m_cvFrame, cv::Size(m_nPropResolutionX, m_nPropResolutionY), 0.0, 0.0, constants::BASICCAM_RESIZE_INTERPOLATION_METHOD);
-
-            // Call FPS tick.
-            m_IPS.Tick();
         }
         else
         {

--- a/src/vision/cameras/ZEDCam.cpp
+++ b/src/vision/cameras/ZEDCam.cpp
@@ -336,9 +336,6 @@ void ZEDCam::ThreadedContinuousCode()
             }
             // Release camera lock.
             lkSharedCameraLock.unlock();
-
-            // Call FPS tick.
-            m_IPS.Tick();
         }
         else
         {


### PR DESCRIPTION
Main Changes:
- Because the IPS instance was moved to AutonomyThread, whereas it was originally placed in Camera.hpp, the Tick() method was getting called twice. Once from inside AutonomyThread and sometimes once from inside the child class's ThreadedContinuousCode(). This lead to very high FPS numbers.

Other Changes:
- Updated the docker install link to point to Docker Engine instead of Docker Desktop. Docker Desktop seems to have too many issues on anything other than Windows.