### PR TITLE
Update Docker Images on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@
   </div>
   <div>
     <a href="https://github.com/MissouriMRDT/Autonomy_Software/pkgs/container/autonomy-jammy">
-      <img src="https://img.shields.io/badge/Ubuntu_Jammy-2023--09--05-orange" alt="jammy-pkg" />
+      <img src="https://img.shields.io/badge/Ubuntu_Jammy-latest-orange" alt="jammy-pkg" />
     </a>
     <a href="https://github.com/MissouriMRDT/Autonomy_Software/pkgs/container/autonomy-focal">
-      <img src="https://img.shields.io/badge/Ubuntu_Focal-2023--09--05-orange" alt="focal-pkg" />
+      <img src="https://img.shields.io/badge/Ubuntu_Focal-latest-orange" alt="focal-pkg" />
     </a>
     <a href="https://github.com/MissouriMRDT/Autonomy_Software/pkgs/container/autonomy-jetpack">
-      <img src="https://img.shields.io/badge/JetPack-2023--09--05-orange" alt="jetpack-pkg" />
+      <img src="https://img.shields.io/badge/JetPack-latest-orange" alt="jetpack-pkg" />
     </a>
   </div>
   <div>


### PR DESCRIPTION
Since we have started using the **latest** tag for our docker images, to make there be less things that have to update when we push a new image, I am just now getting around to getting the README to not need to be updated anymore.