### PR TITLE
DriveBoard Class and `diffdrive` Namespace Cleanup

### DIFF
--- a/src/AutonomyConstants.h
+++ b/src/AutonomyConstants.h
@@ -48,16 +48,16 @@ namespace constants
     const float DRIVE_MIN_EFFORT = -0.5;
 
     // Control constants.
-    const double DRIVE_PID_PROPORTIONAL       = 0.1;      // The proportional gain for the controller used to point the rover at a goal heading during navigation.
-    const double DRIVE_PID_INTEGRAL           = 0.01;     // The integral gain for the controller used to point the rover at a goal heading during navigation.
-    const double DRIVE_PID_DERIVATIVE         = 0.0;      // The derivative gain for the controller used to point the rover at a goal heading during navigation.
-    const double DRIVE_PID_MAX_ERROR_PER_ITER = 100;      // The max allowable error the controller will see per iteration. This is on degrees from setpoint.
-    const double DRIVE_PID_MAX_INTEGRAL_TERM  = 0.3;      // The max effort the I term is allowed to contribute.
-    const double DRIVE_PID_MAX_OUTPUT_EFFORT  = 0.5;      // The max effort the entire PID controller is allowed to output. Range is within DRIVE_MAX/MIN_POWER.
-    const double DRIVE_PID_MAX_RAMP_RATE      = 0.4;      // The max ramp rate of the output of the PID controller.
-    const double DRIVE_PID_OUTPUT_FILTER      = 0.0;      // Larger values will filter out large spikes or oscillations. 0.1 is a good starting point.
-    const bool DRIVE_PID_OUTPUT_REVERSED      = false;    // Negates the output of the PID controller.
-    const bool DRIVE_SQUARE_CONTROL_INPUTS    = false;    // This is used by the DifferentialDrive algorithms. True makes fine inputs smoother, but less responsive.
+    const double DRIVE_PID_PROPORTIONAL       = 0.1;     // The proportional gain for the controller used to point the rover at a goal heading during navigation.
+    const double DRIVE_PID_INTEGRAL           = 0.01;    // The integral gain for the controller used to point the rover at a goal heading during navigation.
+    const double DRIVE_PID_DERIVATIVE         = 0.0;     // The derivative gain for the controller used to point the rover at a goal heading during navigation.
+    const double DRIVE_PID_MAX_ERROR_PER_ITER = 100;     // The max allowable error the controller will see per iteration. This is on degrees from setpoint.
+    const double DRIVE_PID_MAX_INTEGRAL_TERM  = 0.3;     // The max effort the I term is allowed to contribute.
+    const double DRIVE_PID_MAX_OUTPUT_EFFORT = DRIVE_MAX_EFFORT;    // The max effort the entire PID controller is allowed to output. Range is within DRIVE_MAX/MIN_POWER.
+    const double DRIVE_PID_MAX_RAMP_RATE     = 0.4;                 // The max ramp rate of the output of the PID controller.
+    const double DRIVE_PID_OUTPUT_FILTER     = 0.0;                 // Larger values will filter out large spikes or oscillations. 0.1 is a good starting point.
+    const bool DRIVE_PID_OUTPUT_REVERSED     = false;               // Negates the output of the PID controller.
+    const bool DRIVE_SQUARE_CONTROL_INPUTS   = false;    // This is used by the DifferentialDrive algorithms. True makes fine inputs smoother, but less responsive.
     const bool DRIVE_CURVATURE_KINEMATICS_ALLOW_TURN_WHILE_STOPPED = true;    // This enabled turning in-place when using curvature drive control.
     ///////////////////////////////////////////////////////////////////////////
 

--- a/src/algorithms/DifferentialDrive.hpp
+++ b/src/algorithms/DifferentialDrive.hpp
@@ -13,6 +13,7 @@
 #define DIFFERENTIAL_DRIVE_HPP
 
 #include "../AutonomyConstants.h"
+#include "../AutonomyLogging.h"
 #include "../util/NumberOperations.hpp"
 #include "controllers/PIDController.h"
 
@@ -222,9 +223,11 @@ namespace diffdrive
      * @param dGoalSpeed - The goal speed for the robot.
      * @param dGoalHeading - The goal absolute heading for the robot. (0-360 degrees, CW positive.)
      * @param dActualHeading - The actual current heading of the robot.
-     * @param eDriveMethod - The differential drive method to use for navigation.
+     * @param eDriveMethod - The differential drive method to use for navigation. MUST NOT BE TANK.
      * @param PID - A reference to the PID controller to use for hitting the heading setpoint.
      * @return DrivePowers - The resultant drive powers.
+     *
+     * @note This method does not support tank drive as a control method.
      *
      * @author clayjay3 (claytonraycowen@gmail.com)
      * @date 2023-10-19
@@ -251,10 +254,11 @@ namespace diffdrive
                                                          constants::DRIVE_SQUARE_CONTROL_INPUTS);
                 break;
             default:
-                stOutputPowers = CalculateCurvatureDrive(dGoalSpeed,
-                                                         dGoalHeading,
-                                                         constants::DRIVE_CURVATURE_KINEMATICS_ALLOW_TURN_WHILE_STOPPED,
-                                                         constants::DRIVE_SQUARE_CONTROL_INPUTS);
+                // Default to arcade drive.
+                stOutputPowers = CalculateArcadeDrive(dGoalSpeed, dGoalHeading, constants::DRIVE_SQUARE_CONTROL_INPUTS);
+
+                // Submit logger message.
+                LOG_WARNING(logging::g_qSharedLogger, "eTankDrive is not supported for the CalculateMotorPowerFromHeading() method!");
                 break;
         }
 

--- a/src/drivers/DriveBoard.cpp
+++ b/src/drivers/DriveBoard.cpp
@@ -62,7 +62,7 @@ DriveBoard::~DriveBoard()
  *
  * @param dGoalSpeed - The speed to drive at (-1 to 1)
  * @param dGoalHeading - The angle to drive towards. (0 - 360) 0 is North.
- * @param dActualHeading -
+ * @param dActualHeading - The real angle that the Rover is current facing.
  * @param eKinematicsMethod - The kinematics model to use for differential drive control. Enum within DifferentialDrive.hpp
  * @return diffdrive::DrivePowers - A struct containing two values. (left power, right power)
  *
@@ -76,9 +76,6 @@ diffdrive::DrivePowers DriveBoard::CalculateMove(const double dGoalSpeed,
 {
     // Calculate the drive powers from the current heading, goal heading, and goal speed.
     m_stDrivePowers = diffdrive::CalculateMotorPowerFromHeading(dGoalSpeed, dGoalHeading, dActualHeading, eKinematicsMethod, *m_pPID);
-
-    // Submit logger message.
-    LOG_DEBUG(logging::g_qSharedLogger, "Driving at: ({}, {})", m_stDrivePowers.dLeftDrivePower, m_stDrivePowers.dRightDrivePower);
 
     return m_stDrivePowers;
 }
@@ -112,6 +109,9 @@ void DriveBoard::SendDrive(double dLeftSpeed, double dRightSpeed)
 
     // Send drive command over RoveComm to drive board.
     // TODO: Add RoveComm sendpacket.
+
+    // Submit logger message.
+    LOG_DEBUG(logging::g_qSharedLogger, "Driving at: ({}, {})", m_stDrivePowers.dLeftDrivePower, m_stDrivePowers.dRightDrivePower);
 }
 
 /******************************************************************************


### PR DESCRIPTION
- Added missing parameter description to docs
- Moved logging statements to be more clean.
- Adjusted constants to be more consistent. 