### PR TITLE
[HOTFIX] - File Existence Plugin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Check File Existence (${{ matrix.type }} Tests)
         id: check
-        uses: andstor/file-existence-action@v2
+        uses: andstor/file-existence-action@v3
         with:
           files: "/opt/Autonomy_Software/build/Autonomy_Software_${{ matrix.type }}Tests"
 


### PR DESCRIPTION
GitHub has deprecated a method used by v2 of the file existence action plugin. It has been resolved in v3.

The file existence plugin aids us in figuring out if we have unit tests existing in a directory.