### PR TITLE
[HOTFIX] - GitHub Artifacts Plugin

### DIFF
--- a/.github/workflows/deploy_autonomy.yml
+++ b/.github/workflows/deploy_autonomy.yml
@@ -89,7 +89,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Delete Artifacts
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v4
         with:
           name: |
             Autonomy-AMD64


### PR DESCRIPTION
GitHub has deprecated a method used by v2 of the artifact action plugins. It has been resolved in v4.

We use these to add and remove files from the artifacts published with GitHub Actions.