### PR TITLE
[HOTFIX] Missed inappropriate #include from AStar merge.

### DIFF
--- a/src/algorithms/planners/AStar.cpp
+++ b/src/algorithms/planners/AStar.cpp
@@ -10,7 +10,7 @@
  ******************************************************************************/
 
 #include "AStar.h"
-#include "../../AutonomyGlobals.h"
+#include "../../AutonomyConstants.h"
 
 /// \cond
 // Put implicit includes in here.


### PR DESCRIPTION
Just changed `#include "../../AutonomyGlobals.h` to `#include "../../AutonomyLogging.h"` to cleanup dependency graphs.

This was missed during the ASTAR PR reviews, didn't notice it until looking at dependency graphs for AStar.cpp in doxygen.