### PR TITLE
Add GPS Based Rover Velocity Calculation to NavBoard

### DIFF
--- a/src/drivers/NavigationBoard.cpp
+++ b/src/drivers/NavigationBoard.cpp
@@ -59,9 +59,8 @@ NavigationBoard::~NavigationBoard() {}
  ******************************************************************************/
 geoops::GPSCoordinate NavigationBoard::GetGPSData()
 {
-    // Acquire read lock for getting UTM struct.
+    // Acquire read lock for getting GPS struct.
     std::shared_lock<std::shared_mutex> lkGPSProcessLock(m_muLocationMutex);
-    // Convert the currently stored UTM coord to GPS and return.
     return m_stLocation;
 }
 
@@ -78,6 +77,7 @@ geoops::UTMCoordinate NavigationBoard::GetUTMData()
 {
     // Acquire read lock for getting UTM struct.
     std::shared_lock<std::shared_mutex> lkGPSProcessLock(m_muLocationMutex);
+    // Convert the currently stored GPS coord to GPS and return.
     return geoops::ConvertGPSToUTM(m_stLocation);
 }
 
@@ -94,4 +94,36 @@ double NavigationBoard::GetHeading()
     // Acquire read lock for getting compass double.
     std::shared_lock<std::shared_mutex> lkCompassProcessLock(m_muHeadingMutex);
     return m_dHeading;
+}
+
+/******************************************************************************
+ * @brief The rover's current velocity based off of the distance covered over the
+ *      last two GPSCoordinates.
+ *
+ * @return double - The rover's velocity in meters per second.
+ *
+ * @author clayjay3 (claytonraycowen@gmail.com)
+ * @date 2024-03-13
+ ******************************************************************************/
+double NavigationBoard::GetVelocity()
+{
+    // Acquire read lock for getting velocity double.
+    std::shared_lock<std::shared_mutex> lkVelocityProcessLock(m_muVelocityMutex);
+    return m_dVelocity;
+}
+
+/******************************************************************************
+ * @brief A chrono timestamp storing the last time autonomy's GPS location was updated
+ *      over RoveComm via the NavBoard.
+ *
+ * @return std::chrono::system_clock::time_point - The timestamp that the current GPSCoordinate location was updated.
+ *
+ * @author clayjay3 (claytonraycowen@gmail.com)
+ * @date 2024-03-13
+ ******************************************************************************/
+std::chrono::system_clock::time_point NavigationBoard::GetGPSTimestamp()
+{
+    // Acquire read lock for getting GPS timestamp.
+    std::shared_lock<std::shared_mutex> lkGPSProcessLock(m_muLocationMutex);
+    return m_tmLastGPSUpdateTime;
 }

--- a/src/drivers/NavigationBoard.cpp
+++ b/src/drivers/NavigationBoard.cpp
@@ -77,7 +77,7 @@ geoops::UTMCoordinate NavigationBoard::GetUTMData()
 {
     // Acquire read lock for getting UTM struct.
     std::shared_lock<std::shared_mutex> lkGPSProcessLock(m_muLocationMutex);
-    // Convert the currently stored GPS coord to GPS and return.
+    // Convert the currently stored GPS coord to UTM and return.
     return geoops::ConvertGPSToUTM(m_stLocation);
 }
 

--- a/src/drivers/NavigationBoard.h
+++ b/src/drivers/NavigationBoard.h
@@ -64,7 +64,7 @@ class NavigationBoard
 
         geoops::GPSCoordinate m_stLocation;                             // Store current global position in UTM format.
         double m_dHeading;                                              // Store current GPS heading.
-        double m_dVelocity;                                             // Store current GPS velocity.
+        double m_dVelocity;                                             // Store current GPS-based velocity.
         std::shared_mutex m_muLocationMutex;                            // Mutex for acquiring read and write lock on location member variable.
         std::shared_mutex m_muHeadingMutex;                             // Mutex for acquiring read and write lock on heading member variable.
         std::shared_mutex m_muVelocityMutex;                            // Mutex for acquiring read and write lock on velocity member variable.

--- a/src/handlers/StateMachineHandler.h
+++ b/src/handlers/StateMachineHandler.h
@@ -33,7 +33,7 @@
  * @author Eli Byrd (edbgkk@mst.edu)
  * @date 2024-01-17
  ******************************************************************************/
-class StateMachineHandler : public AutonomyThread<void>
+class StateMachineHandler : private AutonomyThread<void>
 {
     private:
         std::shared_ptr<statemachine::State> pCurrentState;
@@ -63,6 +63,8 @@ class StateMachineHandler : public AutonomyThread<void>
         statemachine::States GetPreviousState() const;
 
         void SaveCurrentState();
+
+        using AutonomyThread::GetIPS;
 };
 
 #endif    // STATEMACHINEHANDLER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,7 +201,7 @@ int main()
                           " Z:" + std::to_string(slCameraLocation.z) + " Heading:" + std::to_string(slGeoPosition.heading) + "\n";
 
             // Submit logger message.
-            LOG_INFO(logging::g_qConsoleLogger, "{}", szMainInfo);
+            LOG_DEBUG(logging::g_qSharedLogger, "{}", szMainInfo);
         }
 
         /////////////////////////////////////////


### PR DESCRIPTION
# Main Changes:
- Added velocity calculation to navboard rovecomm callback.
    - **This will be useful for the stuck state and perhaps searchpattern**
- Added accessor for getting rover velocity and latest GPS data timestamp.

## Other Changes:
- Changed StateMachineHandler's AutonomyThread parent class to be private since users are meant to call StateMachineHandler methods for starting and stopping the state machine (not directly use AutonomyThread methods)
    - `GetIPS()` is still accessible for getting FPS info of the background thread.
- Changed thread FPS to be a debug print and added it to the file logger.