### PR TITLE
Upgrade to Quill 3.7.0

### DIFF
--- a/.devcontainer/Dockerfile_Jammy
+++ b/.devcontainer/Dockerfile_Jammy
@@ -88,7 +88,7 @@ RUN wget -q https://github.com/MissouriMRDT/Autonomy_Packages/raw/main/geolib/am
     rm geolib_${GEOLIB_VERSION}_amd64.deb
 
 # Install Quill
-ARG QUILL_VERSION="3.6.0"
+ARG QUILL_VERSION="3.7.0"
 RUN wget -q https://github.com/MissouriMRDT/Autonomy_Packages/raw/main/quill/amd64/quill_${QUILL_VERSION}_amd64.deb && \
     dpkg -i quill_${QUILL_VERSION}_amd64.deb && \
     rm quill_${QUILL_VERSION}_amd64.deb

--- a/.devcontainer/Dockerfile_JetPack
+++ b/.devcontainer/Dockerfile_JetPack
@@ -83,7 +83,7 @@ RUN wget -q https://github.com/MissouriMRDT/Autonomy_Packages/raw/main/geolib/ar
     rm geolib_${GEOLIB_VERSION}_arm64.deb
 
 # Install Quill
-ARG QUILL_VERSION="3.6.0"
+ARG QUILL_VERSION="3.7.0"
 RUN wget -q https://github.com/MissouriMRDT/Autonomy_Packages/raw/main/quill/arm64/quill_${QUILL_VERSION}_arm64.deb && \
     dpkg -i quill_${QUILL_VERSION}_arm64.deb && \
     rm quill_${QUILL_VERSION}_arm64.deb

--- a/tools/package-builders/quill/quill-amd64-pkg.sh
+++ b/tools/package-builders/quill/quill-amd64-pkg.sh
@@ -4,7 +4,7 @@
 cd /tmp
 
 # Install Variables
-QUILL_VERSION="3.6.0"
+QUILL_VERSION="3.7.0"
 
 # Define Package URL
 FILE_URL="https://github.com/MissouriMRDT/Autonomy_Packages/raw/main/quill/amd64/quill_${QUILL_VERSION}_amd64.deb"

--- a/tools/package-builders/quill/quill-arm64-pkg.sh
+++ b/tools/package-builders/quill/quill-arm64-pkg.sh
@@ -4,7 +4,7 @@
 cd /tmp
 
 # Install Variables
-QUILL_VERSION="3.6.0"
+QUILL_VERSION="3.7.0"
 
 # Define Package URL
 FILE_URL="https://github.com/MissouriMRDT/Autonomy_Packages/raw/main/quill/arm64/quill_${QUILL_VERSION}_arm64.deb"


### PR DESCRIPTION
# Changelog from [Quill 3.6.0 to 3.7.0](https://github.com/odygrd/quill/releases/tag/v3.7.0)
- Fixed crash triggered by insufficient space in the queue upon invocation of flush(). 
- Fixed windows clang-cl build error.
- Fixed compilation errors encountered on FreeBSD and extended get_thread_id() support to various other BSD operating systems.
- Fix open_file() in the FileHandler to also create the parent path before opening the file.
- Enhance logic for backend thread's flush() invocation; it now triggers only if the handler has previously written data.
- Address an uncaught exception in the backend thread that could occur when a user manually removes the log file from the terminal while the logger is running.
- Ensure that after a logger is removed, there are no subsequent calls to the Handler's flush() or run_loop(), provided the Handler is not shared.
- Ignore the virtual destructor missing warning for the CustomTags class.
- Update bundled libfmt to v10.2.1