### PR TITLE
Fix TODO-Tree Extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -166,21 +166,48 @@
                 "doxdocgen.generic.useGitUserName": true,
                 // Todo Tree Extention Settings
                 "todo-tree.general.tags": [
-                    "FIXME:",
-                    "TODO:",
-                    "LEAD:",
-                    "ISSUE NOTE:"
+                    "TODO",
+                    "BUG",
+                    "HACK",
+                    "FIXME",
+                    "LEAD",
+                    "ISSUE NOTE",
+                    "TEST",
+                    "[ ]",
+                    "[x]"
                 ],
+                "todo-tree.highlights.defaultHighlight": {
+                    "icon": "alert",
+                    "type": "text",
+                    "foreground": "#00ff00",
+                    "background": "#ffffff",
+                    "opacity": 50,
+                    "iconColour": "#00ff00"
+                },
                 "todo-tree.highlights.customHighlight": {
                     "TODO": {
-                        "icon": "check",
+                        "icon": "bookmark",
                         "type": "line",
                         "iconColour": "#d000ff",
                         "foreground": "#ffffff",
                         "background": "#d000ff"
                     },
+                    "BUG": {
+                        "icon": "bug",
+                        "type": "line",
+                        "iconColour": "#ff8c00",
+                        "foreground": "#ffffff",
+                        "background": "#ff8c00"
+                    },
+                    "HACK": {
+                        "icon": "circle-slash",
+                        "type": "line",
+                        "iconColour": "#ff1e00",
+                        "foreground": "#ffffff",
+                        "background": "#ff1e00"
+                    },
                     "FIXME": {
-                        "icon": "beaker",
+                        "icon": "alert-fill",
                         "type": "line",
                         "iconColour": "#ff0000",
                         "foreground": "#ffffff",
@@ -189,22 +216,22 @@
                     "LEAD": {
                         "icon": "person",
                         "type": "line",
-                        "iconColour": "#ffffff",
-                        "foreground": "#000000",
-                        "background": "#ffffff"
+                        "iconColour": "#0700d8",
+                        "foreground": "#ffffff",
+                        "background": "#0700d8"
                     },
                     "ISSUE NOTE": {
                         "icon": "book",
                         "type": "line",
                         "iconColour": "#808080",
-                        "foreground": "#000000",
+                        "foreground": "#ffffff",
                         "background": "#808080"
                     },
                     "TEST": {
-                        "icon": "book",
+                        "icon": "beaker",
                         "type": "line",
                         "iconColour": "#c5cb04",
-                        "foreground": "#000000",
+                        "foreground": "#ffffff",
                         "background": "#ccd514"
                     }
                 },

--- a/src/states/ApproachingObjectState.cpp
+++ b/src/states/ApproachingObjectState.cpp
@@ -78,6 +78,14 @@ namespace statemachine
     void ApproachingObjectState::Run()
     {
         // TODO: Implement the behavior specific to the Approaching Object state
+        // BUG: This breaks occasionally.
+        // HACK: This is bad, never do this.
+        // FIXME: AAAHAHAHHAAH
+        // LEAD: AHAHAHAHA
+        // ISSUE NOTE: WHAT THE HELL
+        // TEST: LKFJLSKDFJLKSDjf
+        // [ ] this is a list item.
+        // [x] this is a checked list item.
         LOG_DEBUG(logging::g_qSharedLogger, "ApproachingObjectState: Running state-specific behavior.");
     }
 


### PR DESCRIPTION
A long time ago the devcontainer.json was changed and the todo-tree extension became broken which caused missing labels and all TODO:s showing up white. Fixed JSON formatting to bring colors back. Also added some new labels and appropriate icons for each label.

I have intentionally made them neon and ugly so that they stand out in the code and have a higher probability of being fixed.

New colors:
![Screenshot from 2024-03-21 21-48-46](https://github.com/MissouriMRDT/Autonomy_Software/assets/26121134/3b1f35e2-d4cc-427f-8fd5-ac8fd9977c40)

New Icons:
![Screenshot from 2024-03-21 21-48-32](https://github.com/MissouriMRDT/Autonomy_Software/assets/26121134/f35ce0f1-ff8c-4005-8284-064a635834c0)


