### PR TITLE
Remove Unneeded Variables from StateMachine

### DIFF
--- a/src/AutonomyLogging.h
+++ b/src/AutonomyLogging.h
@@ -120,7 +120,7 @@ namespace logging
                 (void) formatted_record;
 
                 // Log only m_eMinLogLevel or higher to stdout.
-                return metadata.level() >= m_eMinLogLevel;
+                return metadata.log_level() >= m_eMinLogLevel;
             }
     };
 

--- a/src/handlers/StateMachineHandler.cpp
+++ b/src/handlers/StateMachineHandler.cpp
@@ -162,8 +162,6 @@ void StateMachineHandler::StartStateMachine()
 {
     // Initialize the state machine with the initial state
     m_pCurrentState    = CreateState(statemachine::States::eIdle);
-
-    m_bInitialized     = true;
     m_bSwitchingStates = false;
 
     // Start the state machine thread
@@ -211,7 +209,7 @@ void StateMachineHandler::ThreadedContinuousCode()
         states. And verify that the state machine is not exiting. This prevents
         the state machine from running after it has been stopped.
     */
-    if (m_bInitialized && !m_bSwitchingStates && !m_bExiting)
+    if (!m_bSwitchingStates)
     {
         // Run the current state
         m_pCurrentState->Run();

--- a/src/handlers/StateMachineHandler.h
+++ b/src/handlers/StateMachineHandler.h
@@ -52,9 +52,7 @@ class StateMachineHandler : private AutonomyThread<void>
         std::unordered_map<statemachine::States, std::shared_ptr<statemachine::State>> m_umExitedStates;
         std::shared_mutex m_muStateMutex;
         std::shared_mutex m_muEventMutex;
-        std::atomic_bool m_bInitialized;
         std::atomic_bool m_bSwitchingStates;
-        std::atomic_bool m_bExiting;
 
         /////////////////////////////////////////
         // Declare private class methods.


### PR DESCRIPTION
Just cleanup to prevent potential unclear or undefined behavior. State machine will still function the same.