### PR TITLE
Fix ZEDCam freeze.

### DIFF
--- a/src/vision/cameras/ZEDCam.cpp
+++ b/src/vision/cameras/ZEDCam.cpp
@@ -447,9 +447,6 @@ void ZEDCam::ThreadedContinuousCode()
                             sl::toString(m_slCamera.getCameraInformation().camera_model).get(),
                             m_unCameraSerialNumber);
             }
-
-            // Release camera lock.
-            lkSharedCameraLock.unlock();
         }
         else
         {


### PR DESCRIPTION
Remove double mutex unlock to fix ZEDCam threads not running.