### PR TITLE
Reconfigure Camera Layout and Add Battery Voltage Monitoring

### DIFF
--- a/data/Custom_Dictionaries/Autonomy-Dictionary.txt
+++ b/data/Custom_Dictionaries/Autonomy-Dictionary.txt
@@ -20,6 +20,7 @@ BASICCAM
 buildcache
 Buildx
 CALIB
+CELLVOLTAGE
 clayjay
 CLEARWAYPOINTS
 codeql

--- a/data/Custom_Dictionaries/Autonomy-Dictionary.txt
+++ b/data/Custom_Dictionaries/Autonomy-Dictionary.txt
@@ -68,6 +68,7 @@ GNSS
 GPSLATLONALT
 GPSMDRS
 GPSSDELC
+GROUNDCAM
 gruntfuggly
 gtest
 hyperthreaded

--- a/examples/vision/cameras/OpenBasicCam.hpp
+++ b/examples/vision/cameras/OpenBasicCam.hpp
@@ -38,7 +38,7 @@ void RunExample()
     globals::g_pCameraHandler = new CameraHandler();
 
     // Get reference to camera.
-    BasicCam* ExampleBasicCam1 = globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadLeftArucoEye);
+    BasicCam* ExampleBasicCam1 = globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadGroundCam);
     // Start basic cam.
     ExampleBasicCam1->Start();
 

--- a/examples/vision/dnn/InferenceYOLOModel.hpp
+++ b/examples/vision/dnn/InferenceYOLOModel.hpp
@@ -37,7 +37,7 @@ void RunExample()
     globals::g_pCameraHandler = new CameraHandler();
 
     // Get reference to camera.
-    BasicCam* ExampleBasicCam1 = globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadLeftArucoEye);
+    BasicCam* ExampleBasicCam1 = globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadGroundCam);
     // Start basic cam.
     ExampleBasicCam1->Start();
 

--- a/examples/vision/tagdetection/ArucoDetectionBasicCam.hpp
+++ b/examples/vision/tagdetection/ArucoDetectionBasicCam.hpp
@@ -29,12 +29,12 @@ void RunExample()
     globals::g_pTagDetectionHandler = new TagDetectionHandler();
 
     // Get pointer to camera.
-    BasicCam* ExampleBasicCam1 = globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadLeftArucoEye);
+    BasicCam* ExampleBasicCam1 = globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadGroundCam);
     // Start basic cam.
     ExampleBasicCam1->Start();
 
     // Get pointer to the tag detector for the basic cam.
-    TagDetector* ExampleTagDetector1 = globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::eHeadLeftArucoEye);
+    TagDetector* ExampleTagDetector1 = new TagDetector(ExampleBasicCam1);
     // Start the basic cam detector.
     ExampleTagDetector1->Start();
 

--- a/src/AutonomyConstants.h
+++ b/src/AutonomyConstants.h
@@ -40,6 +40,9 @@ namespace constants
     const bool MODE_SIM = false;    // REG MODE ENABLED: Toggle RoveComm and Cameras to use standard configuration.
 #endif
 
+    // Safety constants.
+    const double BATTERY_MINIMUM_CELL_VOLTAGE = 3.2;    // The minimum cell voltage of the battery before autonomy will forcefully enter Idle state.
+
     // Logging constants.
     const std::string LOGGING_OUTPUT_PATH_ABSOLUTE = "./logs/";    // The absolute to write output logging and video files to.
 

--- a/src/AutonomyConstants.h
+++ b/src/AutonomyConstants.h
@@ -81,13 +81,15 @@ namespace constants
     // Recording adjustments.
     const int RECORDER_FPS = 15;    // The FPS all recordings should run at.
     // Camera recording toggles.
-    const bool ZED_MAINCAM_ENABLE_RECORDING       = true;    // Whether or not to record the main ZED camera.
-    const bool BASICCAM_LEFTCAM_ENABLE_RECORDING  = true;    // Whether or not to record the left USB camera.
-    const bool BASICCAM_RIGHTCAM_ENABLE_RECORDING = true;    // Whether or not to record the right USB camera.
+    const bool ZED_MAINCAM_ENABLE_RECORDING        = true;    // Whether or not to record the main ZED camera.
+    const bool ZED_LEFTCAM_ENABLE_RECORDING        = true;    // Whether or not to record the left ZED camera.
+    const bool ZED_RIGHTCAM_ENABLE_RECORDING       = true;    // Whether or not to record the right ZED camera.
+    const bool BASICCAM_GROUNDCAM_ENABLE_RECORDING = true;    // Whether or not to record the ground USB camera.
     // TagDetector recording toggles.
-    const bool TAGDETECT_MAINCAM_ENABLE_RECORDING  = true;    // Whether or not to record the main ZED camera tag detector.
-    const bool TAGDETECT_LEFTCAM_ENABLE_RECORDING  = true;    // Whether or not to record the left USB camera tag detector.
-    const bool TAGDETECT_RIGHTCAM_ENABLE_RECORDING = true;    // Whether or not to record the right USB camera tag detector.
+    const bool TAGDETECT_MAINCAM_ENABLE_RECORDING   = true;    // Whether or not to record the main ZED camera tag detector.
+    const bool TAGDETECT_LEFTCAM_ENABLE_RECORDING   = true;    // Whether or not to record the left ZED camera tag detector.
+    const bool TAGDETECT_RIGHTCAM_ENABLE_RECORDING  = true;    // Whether or not to record the right ZED camera tag detector.
+    const bool TAGDETECT_GROUNDCAM_ENABLE_RECORDING = true;    // Whether of not to record the ground USB camera tag detector.
     ///////////////////////////////////////////////////////////////////////////
 
     ///////////////////////////////////////////////////////////////////////////
@@ -152,27 +154,41 @@ namespace constants
     const bool ZED_MAINCAM_USE_HALF_PRECISION_DEPTH = true;        // Whether of not to use float32 or unsigned short (16) for depth measure.
     const bool ZED_MAINCAM_FUSION_MASTER            = true;        // Whether or not this camera will host the master instance of the ZEDSDK Fusion capabilities.
     const int ZED_MAINCAM_FRAME_RETRIEVAL_THREADS   = 5;           // The number of threads allocated to the threadpool for performing frame copies to other threads.
-    const int ZED_MAINCAM_SERIAL                    = 15723847;    // The serial number of the camera. Set to 0 to open the next available one. 31237348
+    const int ZED_MAINCAM_SERIAL                    = 31237348;    // The serial number of the camera. Set to 0 to open the next available one. 31237348
 
-    // Left Side Cam.
-    const int BASICCAM_LEFTCAM_RESOLUTIONX             = 1280;    // The horizontal pixel resolution to resize the maincam images to.
-    const int BASICCAM_LEFTCAM_RESOLUTIONY             = 720;     // The vertical pixel resolution to resize the maincam images to.
-    const int BASICCAM_LEFTCAM_FPS                     = 30;      // The FPS to use for the maincam.
-    const int BASICCAM_LEFTCAM_HORIZONTAL_FOV          = 110;     // The horizontal FOV of the camera. Useful for future calculations.
-    const int BASICCAM_LEFTCAM_VERTICAL_FOV            = 70;      // The vertical FOV of the camera. Useful for future calculations.
-    const int BASICCAM_LEFTCAM_FRAME_RETRIEVAL_THREADS = 5;       // The number of threads allocated to the threadpool for performing frame copies to other threads.
-    const int BASICCAM_LEFTCAM_INDEX                   = 0;       // The /dev/video index of the camera.
-    const PIXEL_FORMATS BASICCAM_LEFTCAM_PIXELTYPE     = PIXEL_FORMATS::eBGR;    // The pixel layout of the camera.
+    // Left ZED Camera.
+    const int ZED_LEFTCAM_RESOLUTIONX               = 1280;        // The horizontal pixel resolution to resize the leftcam images to.
+    const int ZED_LEFTCAM_RESOLUTIONY               = 720;         // The vertical pixel resolution to resize the leftcam images to.
+    const int ZED_LEFTCAM_FPS                       = 60;          // The FPS to use for the leftcam.
+    const int ZED_LEFTCAM_HORIZONTAL_FOV            = 110;         // The horizontal FOV of the camera. Useful for future calculations.
+    const int ZED_LEFTCAM_VERTICAL_FOV              = 70;          // The vertical FOV of the camera. Useful for future calculations.
+    const bool ZED_LEFTCAM_USE_GPU_MAT              = true;        // Whether or not to use CPU or GPU memory mats. GPU memory transfer/operations are faster.
+    const bool ZED_LEFTCAM_USE_HALF_PRECISION_DEPTH = true;        // Whether of not to use float32 or unsigned short (16) for depth measure.
+    const bool ZED_LEFTCAM_FUSION_MASTER            = false;       // Whether or not this camera will host the master instance of the ZEDSDK Fusion capabilities.
+    const int ZED_LEFTCAM_FRAME_RETRIEVAL_THREADS   = 5;           // The number of threads allocated to the threadpool for performing frame copies to other threads.
+    const int ZED_LEFTCAM_SERIAL                    = 15723847;    // The serial number of the camera. Set to 0 to open the next available one. 15723847
 
-    // Right Side Cam.
-    const int BASICCAM_RIGHTCAM_RESOLUTIONX             = 1280;    // The horizontal pixel resolution to resize the maincam images to.
-    const int BASICCAM_RIGHTCAM_RESOLUTIONY             = 720;     // The vertical pixel resolution to resize the maincam images to.
-    const int BASICCAM_RIGHTCAM_FPS                     = 30;      // The FPS to use for the maincam.
-    const int BASICCAM_RIGHTCAM_HORIZONTAL_FOV          = 110;     // The horizontal FOV of the camera. Useful for future calculations.
-    const int BASICCAM_RIGHTCAM_VERTICAL_FOV            = 70;      // The vertical FOV of the camera. Useful for future calculations.
-    const int BASICCAM_RIGHTCAM_FRAME_RETRIEVAL_THREADS = 5;       // The number of threads allocated to the threadpool for performing frame copies to other threads.
-    const int BASICCAM_RIGHTCAM_INDEX                   = 2;       // The /dev/video index of the camera.
-    const PIXEL_FORMATS BASICCAM_RIGHTCAM_PIXELTYPE     = PIXEL_FORMATS::eBGR;    // The pixel layout of the camera.
+    // Right ZED Camera.
+    const int ZED_RIGHTCAM_RESOLUTIONX               = 1280;     // The horizontal pixel resolution to resize the rightcam images to.
+    const int ZED_RIGHTCAM_RESOLUTIONY               = 720;      // The vertical pixel resolution to resize the rightcam images to.
+    const int ZED_RIGHTCAM_FPS                       = 60;       // The FPS to use for the rightcam.
+    const int ZED_RIGHTCAM_HORIZONTAL_FOV            = 110;      // The horizontal FOV of the camera. Useful for future calculations.
+    const int ZED_RIGHTCAM_VERTICAL_FOV              = 70;       // The vertical FOV of the camera. Useful for future calculations.
+    const bool ZED_RIGHTCAM_USE_GPU_MAT              = true;     // Whether or not to use CPU or GPU memory mats. GPU memory transfer/operations are faster.
+    const bool ZED_RIGHTCAM_USE_HALF_PRECISION_DEPTH = true;     // Whether of not to use float32 or unsigned short (16) for depth measure.
+    const bool ZED_RIGHTCAM_FUSION_MASTER            = false;    // Whether or not this camera will host the master instance of the ZEDSDK Fusion capabilities.
+    const int ZED_RIGHTCAM_FRAME_RETRIEVAL_THREADS   = 5;        // The number of threads allocated to the threadpool for performing frame copies to other threads.
+    const int ZED_RIGHTCAM_SERIAL                    = 0;        // The serial number of the camera. Set to 0 to open the next available one. 0
+
+    // Ground Basic Cam.
+    const int BASICCAM_GROUNDCAM_RESOLUTIONX             = 1280;    // The horizontal pixel resolution to resize the basiccam images to.
+    const int BASICCAM_GROUNDCAM_RESOLUTIONY             = 720;     // The vertical pixel resolution to resize the basiccam images to.
+    const int BASICCAM_GROUNDCAM_FPS                     = 30;      // The FPS to use for the basiccam.
+    const int BASICCAM_GROUNDCAM_HORIZONTAL_FOV          = 110;     // The horizontal FOV of the camera. Useful for future calculations.
+    const int BASICCAM_GROUNDCAM_VERTICAL_FOV            = 70;      // The vertical FOV of the camera. Useful for future calculations.
+    const int BASICCAM_GROUNDCAM_FRAME_RETRIEVAL_THREADS = 5;       // The number of threads allocated to the threadpool for performing frame copies to other threads.
+    const int BASICCAM_GROUNDCAM_INDEX                   = 0;       // The /dev/video index of the camera.
+    const PIXEL_FORMATS BASICCAM_GROUNDCAM_PIXELTYPE     = PIXEL_FORMATS::eBGR;    // The pixel layout of the camera.
     ///////////////////////////////////////////////////////////////////////////
 
     ///////////////////////////////////////////////////////////////////////////
@@ -204,7 +220,7 @@ namespace constants
     const bool TAGDETECT_MAINCAM_ENABLE_DNN             = false;                            // Whether or not to use DNN detection on top of ArUco.
     const std::string TAGDETECT_MAINCAM_MODEL_PATH      = "../data/models/yolo_models/marsrover_x640/best_edgetpu.tflite";    // The model path to use for detection.
 
-    // Left Side Cam.
+    // Left ZED Camera.
     const int TAGDETECT_LEFTCAM_DATA_RETRIEVAL_THREADS  = 2;     // The number of threads allocated to the threadpool for performing data copies to other threads.
     const int TAGDETECT_LEFTCAM_CORNER_REFINE_MAX_ITER  = 30;    // The maximum number of iterations to run corner refinement on the image.
     const int TAGDETECT_LEFTCAM_CORNER_REFINE_METHOD    = cv::aruco::CORNER_REFINE_NONE;    // Algorithm used to refine tag corner pixels.
@@ -215,7 +231,7 @@ namespace constants
     const bool TAGDETECT_LEFTCAM_ENABLE_DNN             = false;                            // Whether or not to use DNN detection on top of ArUco.
     const std::string TAGDETECT_LEFTCAM_MODEL_PATH      = "../data/models/yolo_models/marsrover_x640/best_edgetpu.tflite";    // The model path to use for detection.
 
-    // Right Side Cam.
+    // Right ZED Camera.
     const int TAGDETECT_RIGHTCAM_DATA_RETRIEVAL_THREADS  = 2;     // The number of threads allocated to the threadpool for performing data copies to other threads.
     const int TAGDETECT_RIGHTCAM_CORNER_REFINE_MAX_ITER  = 30;    // The maximum number of iterations to run corner refinement on the image.
     const int TAGDETECT_RIGHTCAM_CORNER_REFINE_METHOD    = cv::aruco::CORNER_REFINE_NONE;    // Algorithm used to refine tag corner pixels.

--- a/src/handlers/CameraHandler.cpp
+++ b/src/handlers/CameraHandler.cpp
@@ -35,27 +35,46 @@ CameraHandler::CameraHandler()
                             constants::ZED_MAINCAM_FRAME_RETRIEVAL_THREADS,
                             constants::ZED_MAINCAM_SERIAL);
 
-    // Initialize Left aruco eye.
-    m_pLeftCam = new BasicCam(constants::BASICCAM_LEFTCAM_INDEX,
-                              constants::BASICCAM_LEFTCAM_RESOLUTIONX,
-                              constants::BASICCAM_LEFTCAM_RESOLUTIONY,
-                              constants::BASICCAM_LEFTCAM_FPS,
-                              constants::BASICCAM_LEFTCAM_PIXELTYPE,
-                              constants::BASICCAM_LEFTCAM_HORIZONTAL_FOV,
-                              constants::BASICCAM_LEFTCAM_VERTICAL_FOV,
-                              constants::BASICCAM_LEFTCAM_ENABLE_RECORDING,
-                              constants::BASICCAM_LEFTCAM_FRAME_RETRIEVAL_THREADS);
+    // Initialize left ZED camera.
+    m_pLeftCam = new ZEDCam(constants::ZED_LEFTCAM_RESOLUTIONX,
+                            constants::ZED_LEFTCAM_RESOLUTIONY,
+                            constants::ZED_LEFTCAM_FPS,
+                            constants::ZED_LEFTCAM_HORIZONTAL_FOV,
+                            constants::ZED_LEFTCAM_VERTICAL_FOV,
+                            constants::ZED_LEFTCAM_ENABLE_RECORDING,
+                            constants::ZED_DEFAULT_MINIMUM_DISTANCE,
+                            constants::ZED_DEFAULT_MAXIMUM_DISTANCE,
+                            constants::ZED_LEFTCAM_USE_GPU_MAT,
+                            constants::ZED_LEFTCAM_USE_HALF_PRECISION_DEPTH,
+                            constants::ZED_LEFTCAM_FUSION_MASTER,
+                            constants::ZED_LEFTCAM_FRAME_RETRIEVAL_THREADS,
+                            constants::ZED_LEFTCAM_SERIAL);
 
-    // Initialize Right aruco eye.
-    m_pRightCam = new BasicCam(constants::BASICCAM_RIGHTCAM_INDEX,
-                               constants::BASICCAM_RIGHTCAM_RESOLUTIONX,
-                               constants::BASICCAM_RIGHTCAM_RESOLUTIONY,
-                               constants::BASICCAM_RIGHTCAM_FPS,
-                               constants::BASICCAM_RIGHTCAM_PIXELTYPE,
-                               constants::BASICCAM_RIGHTCAM_HORIZONTAL_FOV,
-                               constants::BASICCAM_RIGHTCAM_VERTICAL_FOV,
-                               constants::BASICCAM_RIGHTCAM_ENABLE_RECORDING,
-                               constants::BASICCAM_RIGHTCAM_FRAME_RETRIEVAL_THREADS);
+    // Initialize right ZED camera.
+    m_pRightCam = new ZEDCam(constants::ZED_RIGHTCAM_RESOLUTIONX,
+                             constants::ZED_RIGHTCAM_RESOLUTIONY,
+                             constants::ZED_RIGHTCAM_FPS,
+                             constants::ZED_RIGHTCAM_HORIZONTAL_FOV,
+                             constants::ZED_RIGHTCAM_VERTICAL_FOV,
+                             constants::ZED_RIGHTCAM_ENABLE_RECORDING,
+                             constants::ZED_DEFAULT_MINIMUM_DISTANCE,
+                             constants::ZED_DEFAULT_MAXIMUM_DISTANCE,
+                             constants::ZED_RIGHTCAM_USE_GPU_MAT,
+                             constants::ZED_RIGHTCAM_USE_HALF_PRECISION_DEPTH,
+                             constants::ZED_RIGHTCAM_FUSION_MASTER,
+                             constants::ZED_RIGHTCAM_FRAME_RETRIEVAL_THREADS,
+                             constants::ZED_RIGHTCAM_SERIAL);
+
+    // Initialize ground eye.
+    m_pGroundCam = new BasicCam(constants::BASICCAM_GROUNDCAM_INDEX,
+                                constants::BASICCAM_GROUNDCAM_RESOLUTIONX,
+                                constants::BASICCAM_GROUNDCAM_RESOLUTIONY,
+                                constants::BASICCAM_GROUNDCAM_FPS,
+                                constants::BASICCAM_GROUNDCAM_PIXELTYPE,
+                                constants::BASICCAM_GROUNDCAM_HORIZONTAL_FOV,
+                                constants::BASICCAM_GROUNDCAM_VERTICAL_FOV,
+                                constants::BASICCAM_GROUNDCAM_ENABLE_RECORDING,
+                                constants::BASICCAM_GROUNDCAM_FRAME_RETRIEVAL_THREADS);
 
     // Initialize recording handler for cameras.
     m_pRecordingHandler = new RecordingHandler(RecordingHandler::RecordingMode::eCameraHandler);
@@ -77,12 +96,14 @@ CameraHandler::~CameraHandler()
     delete m_pMainCam;
     delete m_pLeftCam;
     delete m_pRightCam;
+    delete m_pGroundCam;
     delete m_pRecordingHandler;
 
     // Set dangling pointers to nullptr.
     m_pMainCam          = nullptr;
     m_pLeftCam          = nullptr;
     m_pRightCam         = nullptr;
+    m_pGroundCam        = nullptr;
     m_pRecordingHandler = nullptr;
 }
 
@@ -97,10 +118,11 @@ void CameraHandler::StartAllCameras()
 {
     // Start ZED cams.
     m_pMainCam->Start();
-
-    // Start basic cams.
     m_pLeftCam->Start();
     m_pRightCam->Start();
+
+    // Start basic cams.
+    m_pGroundCam->Start();
 }
 
 /******************************************************************************
@@ -131,13 +153,15 @@ void CameraHandler::StopAllCameras()
 
     // Stop ZED cams.
     m_pMainCam->RequestStop();
-    m_pMainCam->Join();
-
-    // Stop basic cams.
     m_pLeftCam->RequestStop();
     m_pRightCam->RequestStop();
+    m_pMainCam->Join();
     m_pLeftCam->Join();
     m_pRightCam->Join();
+
+    // Stop basic cams.
+    m_pGroundCam->RequestStop();
+    m_pGroundCam->Join();
 }
 
 /******************************************************************************
@@ -168,7 +192,9 @@ ZEDCam* CameraHandler::GetZED(ZEDCamName eCameraName)
     // Determine which camera should be returned.
     switch (eCameraName)
     {
-        case eHeadMainCam: return m_pMainCam;
+        case eHeadMainCam: return m_pMainCam;       // Return the ZEDCam in the autonomy head.
+        case eFrameLeftCam: return m_pLeftCam;      // Return the ZEDCam on the left side of the rover frame.
+        case eFrameRightCam: return m_pRightCam;    // Return the ZEDCam on the right side of the rover frame.
         default: return m_pMainCam;
     }
 }
@@ -187,8 +213,7 @@ BasicCam* CameraHandler::GetBasicCam(BasicCamName eCameraName)
     // Determine which camera should be returned.
     switch (eCameraName)
     {
-        case eHeadLeftArucoEye: return m_pLeftCam;      // Return the left fisheye cam in the autonomy head.
-        case eHeadRightArucoEye: return m_pRightCam;    // No camera to return yet.
-        default: return m_pLeftCam;
+        case eHeadGroundCam: return m_pGroundCam;    // Return the ground fisheye cam in the autonomy head.
+        default: return m_pGroundCam;
     }
 }

--- a/src/handlers/CameraHandler.h
+++ b/src/handlers/CameraHandler.h
@@ -38,8 +38,9 @@ class CameraHandler
         /////////////////////////////////////////
 
         ZEDCam* m_pMainCam;
-        BasicCam* m_pLeftCam;
-        BasicCam* m_pRightCam;
+        ZEDCam* m_pLeftCam;
+        ZEDCam* m_pRightCam;
+        BasicCam* m_pGroundCam;
         RecordingHandler* m_pRecordingHandler;
 
     public:
@@ -51,14 +52,15 @@ class CameraHandler
         {
             ZEDCAM_START,
             eHeadMainCam,
+            eFrameLeftCam,
+            eFrameRightCam,
             ZEDCAM_END
         };
 
         enum BasicCamName    // Enum for different basic cameras.
         {
             BASICCAM_START,
-            eHeadLeftArucoEye,
-            eHeadRightArucoEye,
+            eHeadGroundCam,
             BASICCAM_END
         };
 

--- a/src/handlers/ObjectDetectionHandler.cpp
+++ b/src/handlers/ObjectDetectionHandler.cpp
@@ -27,12 +27,14 @@ ObjectDetectionHandler::ObjectDetectionHandler()
                                                   constants::ZED_MAINCAM_USE_GPU_MAT);
 
     // Initialize detector for left aruco BasicCam.
-    m_pObjectDetectorLeftCam =
-        new ObjectDetector(globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadLeftArucoEye), constants::OBJECTDETECT_LEFTCAM_DATA_RETRIEVAL_THREADS, false);
+    m_pObjectDetectorLeftCam = new ObjectDetector(globals::g_pCameraHandler->GetZED(CameraHandler::eFrameLeftCam),
+                                                  constants::OBJECTDETECT_LEFTCAM_DATA_RETRIEVAL_THREADS,
+                                                  constants::ZED_LEFTCAM_USE_GPU_MAT);
 
     // Initialize detector for right aruco BasicCam.
-    m_pObjectDetectorRightCam =
-        new ObjectDetector(globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadRightArucoEye), constants::OBJECTDETECT_RIGHTCAM_DATA_RETRIEVAL_THREADS, false);
+    m_pObjectDetectorRightCam = new ObjectDetector(globals::g_pCameraHandler->GetZED(CameraHandler::eFrameRightCam),
+                                                   constants::OBJECTDETECT_RIGHTCAM_DATA_RETRIEVAL_THREADS,
+                                                   constants::ZED_RIGHTCAM_USE_GPU_MAT);
 }
 
 /******************************************************************************
@@ -110,8 +112,8 @@ ObjectDetector* ObjectDetectionHandler::GetObjectDetector(ObjectDetectors eDetec
     switch (eDetectorName)
     {
         case eHeadMainCam: return m_pObjectDetectorMainCam;
-        case eHeadLeftEye: return m_pObjectDetectorLeftCam;
-        case eHeadRightEye: return m_pObjectDetectorRightCam;
+        case eFrameLeftCam: return m_pObjectDetectorLeftCam;
+        case eFrameRightCam: return m_pObjectDetectorRightCam;
         default: return m_pObjectDetectorMainCam;
     }
 }

--- a/src/handlers/ObjectDetectionHandler.h
+++ b/src/handlers/ObjectDetectionHandler.h
@@ -42,8 +42,8 @@ class ObjectDetectionHandler
         enum ObjectDetectors    // Enum for different cameras that detectors are being ran on.
         {
             eHeadMainCam,
-            eHeadLeftEye,
-            eHeadRightEye
+            eFrameLeftCam,
+            eFrameRightCam
         };
 
         /////////////////////////////////////////

--- a/src/handlers/StateMachineHandler.cpp
+++ b/src/handlers/StateMachineHandler.cpp
@@ -28,6 +28,7 @@ StateMachineHandler::StateMachineHandler()
     // Set RoveComm Node callbacks.
     network::g_pRoveCommUDPNode->AddUDPCallback<uint8_t>(AutonomyStartCallback, manifest::Autonomy::COMMANDS.find("STARTAUTONOMY")->second.DATA_ID);
     network::g_pRoveCommUDPNode->AddUDPCallback<uint8_t>(AutonomyStopCallback, manifest::Autonomy::COMMANDS.find("DISABLEAUTONOMY")->second.DATA_ID);
+    network::g_pRoveCommUDPNode->AddUDPCallback<float>(BMSCellVoltageCallback, manifest::BMS::TELEMETRY.find("CELLVOLTAGE")->second.DATA_ID);
 
     // State machine doesn't need to run at an unlimited speed. Cap main thread to a certain amount of iterations per second.
     this->SetMainThreadIPSLimit(constants::STATEMACHINE_MAX_IPS);

--- a/src/handlers/TagDetectionHandler.cpp
+++ b/src/handlers/TagDetectionHandler.cpp
@@ -33,8 +33,8 @@ TagDetectionHandler::TagDetectionHandler()
                                             constants::TAGDETECT_MAINCAM_DATA_RETRIEVAL_THREADS,
                                             constants::ZED_MAINCAM_USE_GPU_MAT);
 
-    // Initialize detector for left aruco BasicCam.
-    m_pTagDetectorLeftCam = new TagDetector(globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadLeftArucoEye),
+    // Initialize detector for left aruco ZEDCam.
+    m_pTagDetectorLeftCam = new TagDetector(globals::g_pCameraHandler->GetZED(CameraHandler::eFrameLeftCam),
                                             constants::TAGDETECT_LEFTCAM_CORNER_REFINE_MAX_ITER,
                                             constants::TAGDETECT_LEFTCAM_CORNER_REFINE_METHOD,
                                             constants::TAGDETECT_LEFTCAM_MARKER_BORDER_BITS,
@@ -45,8 +45,8 @@ TagDetectionHandler::TagDetectionHandler()
                                             constants::TAGDETECT_LEFTCAM_DATA_RETRIEVAL_THREADS,
                                             false);
 
-    // Initialize detector for right aruco BasicCam.
-    m_pTagDetectorRightCam = new TagDetector(globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadRightArucoEye),
+    // Initialize detector for right aruco ZEDCam.
+    m_pTagDetectorRightCam = new TagDetector(globals::g_pCameraHandler->GetZED(CameraHandler::eFrameRightCam),
                                              constants::TAGDETECT_RIGHTCAM_CORNER_REFINE_MAX_ITER,
                                              constants::TAGDETECT_RIGHTCAM_CORNER_REFINE_METHOD,
                                              constants::TAGDETECT_RIGHTCAM_MARKER_BORDER_BITS,
@@ -128,10 +128,10 @@ void TagDetectionHandler::StartAllDetectors()
 {
     // Start ZED maincam detector.
     m_pTagDetectorMainCam->Start();
-
-    // Start the left and right aruco eyes.
     m_pTagDetectorLeftCam->Start();
     m_pTagDetectorRightCam->Start();
+
+    // Start the BasicCam aruco eyes.
 }
 
 /******************************************************************************
@@ -160,15 +160,15 @@ void TagDetectionHandler::StopAllDetectors()
     m_pRecordingHandler->RequestStop();
     m_pRecordingHandler->Join();
 
-    // Stop ZED maincam detector.
+    // Stop ZED detectors.
     m_pTagDetectorMainCam->RequestStop();
-    m_pTagDetectorMainCam->Join();
-
-    // Stop BasicCam left aruco eye detector.
     m_pTagDetectorLeftCam->RequestStop();
     m_pTagDetectorRightCam->RequestStop();
+    m_pTagDetectorMainCam->Join();
     m_pTagDetectorLeftCam->Join();
     m_pTagDetectorRightCam->Join();
+
+    // Stop BasicCam aruco eye detectors.
 }
 
 /******************************************************************************
@@ -200,8 +200,8 @@ TagDetector* TagDetectionHandler::GetTagDetector(TagDetectors eDetectorName)
     switch (eDetectorName)
     {
         case eHeadMainCam: return m_pTagDetectorMainCam;
-        case eHeadLeftArucoEye: return m_pTagDetectorLeftCam;
-        case eHeadRightArucoEye: return m_pTagDetectorRightCam;
+        case eFrameLeftCam: return m_pTagDetectorLeftCam;
+        case eFrameRightCam: return m_pTagDetectorRightCam;
         default: return m_pTagDetectorMainCam;
     }
 }

--- a/src/handlers/TagDetectionHandler.h
+++ b/src/handlers/TagDetectionHandler.h
@@ -34,6 +34,7 @@ class TagDetectionHandler
         TagDetector* m_pTagDetectorMainCam;
         TagDetector* m_pTagDetectorLeftCam;
         TagDetector* m_pTagDetectorRightCam;
+        TagDetector* m_pTagDetectorGroundCam;
         RecordingHandler* m_pRecordingHandler;
 
     public:
@@ -45,8 +46,8 @@ class TagDetectionHandler
         {
             TAGDETECTOR_START,
             eHeadMainCam,
-            eHeadLeftArucoEye,
-            eHeadRightArucoEye,
+            eFrameLeftCam,
+            eFrameRightCam,
             TAGDETECTOR_END
         };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,11 +155,12 @@ int main()
         /////////////////////////////////////////
         // Get Camera and Tag detector pointers .
         ZEDCam* pMainCam            = globals::g_pCameraHandler->GetZED(CameraHandler::eHeadMainCam);
-        BasicCam* pLeftCam          = globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadLeftArucoEye);
-        BasicCam* pRightCam         = globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadRightArucoEye);
+        ZEDCam* pLeftCam            = globals::g_pCameraHandler->GetZED(CameraHandler::eFrameLeftCam);
+        ZEDCam* pRightCam           = globals::g_pCameraHandler->GetZED(CameraHandler::eFrameRightCam);
+        BasicCam* pGroundCam        = globals::g_pCameraHandler->GetBasicCam(CameraHandler::eHeadGroundCam);
         TagDetector* pMainDetector  = globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::eHeadMainCam);
-        TagDetector* pLeftDetector  = globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::eHeadLeftArucoEye);
-        TagDetector* pRightDetector = globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::eHeadRightArucoEye);
+        TagDetector* pLeftDetector  = globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::eFrameLeftCam);
+        TagDetector* pRightDetector = globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::eFrameRightCam);
         IPS IterPerSecond           = IPS();
 
         // Camera and TagDetector config.
@@ -190,6 +191,7 @@ int main()
             szMainInfo += "MainCam FPS: " + std::to_string(pMainCam->GetIPS().GetExactIPS()) + "\n";
             szMainInfo += "LeftCam FPS: " + std::to_string(pLeftCam->GetIPS().GetExactIPS()) + "\n";
             szMainInfo += "RightCam FPS: " + std::to_string(pRightCam->GetIPS().GetExactIPS()) + "\n";
+            szMainInfo += "GroundCam FPS: " + std::to_string(pGroundCam->GetIPS().GetExactIPS()) + "\n";
             szMainInfo += "MainDetector FPS: " + std::to_string(pMainDetector->GetIPS().GetExactIPS()) + "\n";
             szMainInfo += "LeftDetector FPS: " + std::to_string(pLeftDetector->GetIPS().GetExactIPS()) + "\n";
             szMainInfo += "RightDetector FPS: " + std::to_string(pRightDetector->GetIPS().GetExactIPS()) + "\n";

--- a/src/states/ApproachingMarkerState.cpp
+++ b/src/states/ApproachingMarkerState.cpp
@@ -40,8 +40,8 @@ namespace statemachine
         m_dLastTargetDistance   = 0;
 
         m_vTagDetectors         = {globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::TagDetectors::eHeadMainCam),
-                                   globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::TagDetectors::eHeadLeftArucoEye),
-                                   globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::TagDetectors::eHeadRightArucoEye)};
+                                   globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::TagDetectors::eFrameLeftCam),
+                                   globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::TagDetectors::eFrameRightCam)};
     }    // namespace statemachine
 
     /******************************************************************************

--- a/src/states/IdleState.cpp
+++ b/src/states/IdleState.cpp
@@ -88,10 +88,17 @@ namespace statemachine
         // Submit logger message.
         LOG_DEBUG(logging::g_qSharedLogger, "IdleState: Running state-specific behavior.");
 
-        // Get the current rover gps position.
-        geoops::UTMCoordinate stCurrentLocation = globals::g_pNavigationBoard->GetUTMData();
-        // Store the Rover's position.
-        m_vRoverPosition.push_back(std::make_tuple(stCurrentLocation.dEasting, stCurrentLocation.dNorthing));
+        // Get the current time and time since last GPS update.
+        std::chrono::system_clock::time_point tmCurrentTime            = std::chrono::system_clock::now();
+        std::chrono::system_clock::time_point tmTimeSinceLastGPSUpdate = globals::g_pNavigationBoard->GetGPSTimestamp();
+        // Check if GPS data is up-to-date.
+        if (std::chrono::duration_cast<std::chrono::seconds>(tmCurrentTime - tmTimeSinceLastGPSUpdate).count() < constants::NAVBOARD_MAX_GPS_DATA_AGE)
+        {
+            // Get the current rover gps position.
+            geoops::UTMCoordinate stCurrentLocation = globals::g_pNavigationBoard->GetUTMData();
+            // Store the Rover's position.
+            m_vRoverPosition.push_back(std::make_tuple(stCurrentLocation.dEasting, stCurrentLocation.dNorthing));
+        }
 
         // If the last state was searchpattern and the waypoint handler has been cleared, reset.
         if (globals::g_pStateMachineHandler->GetPreviousState() != States::eIdle && globals::g_pWaypointHandler->GetWaypointCount() <= 0)

--- a/src/states/SearchPatternState.cpp
+++ b/src/states/SearchPatternState.cpp
@@ -51,8 +51,8 @@ namespace statemachine
         m_nSearchPathIdx        = 0;
 
         m_vTagDetectors         = {globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::TagDetectors::eHeadMainCam),
-                                   globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::TagDetectors::eHeadLeftArucoEye),
-                                   globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::TagDetectors::eHeadRightArucoEye)};
+                                   globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::TagDetectors::eFrameLeftCam),
+                                   globals::g_pTagDetectionHandler->GetTagDetector(TagDetectionHandler::TagDetectors::eFrameRightCam)};
     }
 
     /******************************************************************************

--- a/src/vision/aruco/TagDetector.cpp
+++ b/src/vision/aruco/TagDetector.cpp
@@ -67,7 +67,7 @@ TagDetector::TagDetector(BasicCam* pBasicCam,
     this->SetMainThreadIPSLimit(nDetectorMaxFPS);
 
     // Submit logger message.
-    LOG_DEBUG(logging::g_qSharedLogger, "TagDetector created for camera at path/index: {}", m_szCameraName);
+    LOG_INFO(logging::g_qSharedLogger, "TagDetector created for camera at path/index: {}", m_szCameraName);
 }
 
 /******************************************************************************
@@ -126,7 +126,7 @@ TagDetector::TagDetector(ZEDCam* pZEDCam,
     this->SetMainThreadIPSLimit(nDetectorMaxFPS);
 
     // Submit logger message.
-    LOG_DEBUG(logging::g_qSharedLogger, "TagDetector created for camera: {}", m_szCameraName);
+    LOG_INFO(logging::g_qSharedLogger, "TagDetector created for camera: {}", m_szCameraName);
 }
 
 /******************************************************************************
@@ -143,7 +143,7 @@ TagDetector::~TagDetector()
     this->Join();
 
     // Submit logger message.
-    LOG_DEBUG(logging::g_qSharedLogger, "TagDetector for camera {} had been successfully destroyed.", this->GetCameraName());
+    LOG_INFO(logging::g_qSharedLogger, "TagDetector for camera {} had been successfully destroyed.", this->GetCameraName());
 }
 
 /******************************************************************************


### PR DESCRIPTION
- Change Handlers to reflect this year's camera layout.
- Autonomy will now forcefully enter IdleState if battery cell voltage gets below an average 3.2 volts per cell.