### PR TITLE
Update README and Git Extension Settings.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -82,6 +82,7 @@
                 // Git settings.
                 "git.autofetch": true,
                 "git.terminalAuthentication": false,
+                "git.detectSubmodules": false,
                 // C/C++ extension settings.
                 "C_Cpp.formatting": "clangFormat",
                 "C_Cpp.default.compilerPath": "/usr/bin/g++-12",

--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@
       <img src="https://img.shields.io/badge/Ubuntu_Jammy-latest-orange" alt="jammy-pkg" />
     </a>
     <a href="https://github.com/MissouriMRDT/Autonomy_Software/pkgs/container/autonomy-jetpack">
-      <img src="https://img.shields.io/badge/NVIDIA_JetPack_5-latest-orange" alt="jetpack-pkg" />
+      <img src="https://img.shields.io/badge/NVIDIA_JetPack_6-latest-orange" alt="jetpack-pkg" />
     </a>
   </div>
   <div>
     <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">
       <img src="https://img.shields.io/badge/license-GPLv3-blue.svg?style=flat-round" alt="license" />
     </a>
-    <a href="https://en.cppreference.com/w/cpp/17">
-      <img src="https://img.shields.io/badge/language-C%2B%2B17-blue.svg?style=flat-round" alt="language" />
+    <a href="https://en.cppreference.com/w/cpp/20">
+      <img src="https://img.shields.io/badge/language-C%2B%2B20-blue.svg?style=flat-round" alt="language" />
     </a>
   </div>
 </div>


### PR DESCRIPTION
- Update main README.md to reflect new image and C++ versions.
- Set VSCode git extension to not show submodules. (just cleanup and less confusing for members when committing and creating new branches)