### PR TITLE
Fix Local Time in Containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,8 @@
     // Mount shared workspace volumes. Bind from host machine to container.
     "mounts": [
         "source=${localWorkspaceFolder}/data/models/zed,target=/usr/local/zed/resources,type=bind,consistency=delegated",
-        "type=bind,source=${localEnv:HOME}/.ssh,target=/root/.ssh"
+        "type=bind,source=${localEnv:HOME}/.ssh,target=/root/.ssh",
+        "type=bind,readonly,source=/etc/localtime,target=/etc/localtime"
     ],
     "image": "ghcr.io/missourimrdt/autonomy-jammy:latest",
     // "image": "ghcr.io/missourimrdt/autonomy-jetpack:latest",

--- a/data/Custom_Dictionaries/Autonomy-Dictionary.txt
+++ b/data/Custom_Dictionaries/Autonomy-Dictionary.txt
@@ -91,6 +91,7 @@ latlon
 LEDRGB
 LEFTCAM
 libedgetpu
+localtime
 MAINCAM
 MAINCAN
 mainpage

--- a/src/AutonomyLogging.cpp
+++ b/src/AutonomyLogging.cpp
@@ -106,15 +106,15 @@ namespace logging
         // Configure Patterns
         qFileHandler->set_pattern("%(time) %(log_level) [%(thread_id)] [%(file_name):%(line_number)] %(message)",        // format
                                   "%Y-%m-%d %H:%M:%S.%Qms",                                                              // timestamp format
-                                  quill::Timezone::GmtTime);                                                             // timestamp's timezone
+                                  quill::Timezone::LocalTime);                                                           // timestamp's timezone
 
         qConsoleHandler->set_pattern("%(time) %(log_level) [%(thread_id)] [%(file_name):%(line_number)] %(message)",     // format
                                      "%Y-%m-%d %H:%M:%S.%Qms",                                                           // timestamp format
-                                     quill::Timezone::GmtTime);                                                          // timestamp's timezone
+                                     quill::Timezone::LocalTime);                                                        // timestamp's timezone
 
         qRoveCommHandler->set_pattern("%(time) %(log_level) [%(thread_id)] [%(file_name):%(line_number)] %(message)",    // format
                                       "%Y-%m-%d %H:%M:%S.%Qms",                                                          // timestamp format
-                                      quill::Timezone::GmtTime);                                                         // timestamp's timezone
+                                      quill::Timezone::LocalTime);                                                       // timestamp's timezone
 
         // Configure Quill
         quill::Config qConfig;


### PR DESCRIPTION
Docker by default uses universal standard time however that causes the loggers and documentation to have incorrect timestamps associated with them. This fixes that and allows for easier debugging and log tracking.


## Changelog
**devcontainer.json**:
- Binded the host systems time and date file to the development container.

**AutonomyLogging.cpp**:
- Switched from GMT to LocalTime since it works and will be easier for bug tracking.

**Autonomy-Dictionary.txt**:
- Added "LocalTime" to custom dictionary.