### PR TITLE
Remove .ssh Bind

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,6 @@
     // Mount shared workspace volumes. Bind from host machine to container.
     "mounts": [
         "source=${localWorkspaceFolder}/data/models/zed,target=/usr/local/zed/resources,type=bind,consistency=delegated",
-        "type=bind,source=${localEnv:HOME}/.ssh,target=/root/.ssh",
         "type=bind,readonly,source=/etc/localtime,target=/etc/localtime"
     ],
     "image": "ghcr.io/missourimrdt/autonomy-jammy:latest",


### PR DESCRIPTION
Remove the now unneeded bind from the .devcontainer.json file since it seems to break permissions on most machines.

Fixed ~/.ssh for each user on the AutonomyPC, so hopefully no more problems persist after this bind is removed.