### PR TITLE
Restrict Permissions for High-Resource GitHub Actions: Deploy Autonomy & Rebuild Docker

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: results.sarif
+          sarif_file: results/${{matrix.language}}.sarif
 
       - name: Cleanup Action Environment
         if: always()

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,11 +74,6 @@ jobs:
         with:
           category: "/language:${{matrix.language}}"
 
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: ${{ github.workspace }}/../results/${{matrix.language}}.sarif
-
       - name: Cleanup Action Environment
         if: always()
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: ${{ github.workspace }}/results/${{matrix.language}}.sarif
+          sarif_file: ${{ github.workspace }}/../results/${{matrix.language}}.sarif
 
       - name: Cleanup Action Environment
         if: always()

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: results/${{matrix.language}}.sarif
+          sarif_file: ${{ github.workspace }}/results/${{matrix.language}}.sarif
 
       - name: Cleanup Action Environment
         if: always()

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,6 +64,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
+          queries: security-extended
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3
@@ -72,6 +73,11 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
 
       - name: Cleanup Action Environment
         if: always()

--- a/.github/workflows/deploy_autonomy.yml
+++ b/.github/workflows/deploy_autonomy.yml
@@ -29,7 +29,9 @@ jobs:
           - os: [self-hosted, linux, ARM64]
             architecture: AMD64
 
-    environment: deploy-autonomy
+    environment:
+      name: deploy-autonomy
+      url: https://github.com/MissouriMRDT/Autonomy_Software/releases
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/deploy_autonomy.yml
+++ b/.github/workflows/deploy_autonomy.yml
@@ -29,6 +29,8 @@ jobs:
           - os: [self-hosted, linux, ARM64]
             architecture: AMD64
 
+    environment: deploy-autonomy
+
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -155,7 +155,11 @@ jobs:
     needs: [time-and-date, check-amd64-packages]
     runs-on: [self-hosted, linux, X64]
     timeout-minutes: 1440
-    environment: rebuild-docker
+    
+    environment:
+      name: docker-packages
+      url: https://github.com/MissouriMRDT/Autonomy_Packages
+      
     if: github.event_name == 'pull_request'
 
     # This strategy is used to run the job for each package that needs to be rebuilt. This allows multiple
@@ -328,7 +332,11 @@ jobs:
     needs: [time-and-date, check-arm64-packages]
     runs-on: [self-hosted, linux, ARM64]
     timeout-minutes: 1440
-    environment: rebuild-docker
+    
+    environment:
+      name: docker-packages
+      url: https://github.com/MissouriMRDT/Autonomy_Packages
+    
     if: github.event_name == 'pull_request'
 
     # This strategy is used to run the job for each package that needs to be rebuilt. This allows multiple

--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -155,6 +155,7 @@ jobs:
     needs: [time-and-date, check-amd64-packages]
     runs-on: [self-hosted, linux, X64]
     timeout-minutes: 1440
+    environment: rebuild-docker
     if: github.event_name == 'pull_request'
 
     # This strategy is used to run the job for each package that needs to be rebuilt. This allows multiple
@@ -327,6 +328,7 @@ jobs:
     needs: [time-and-date, check-arm64-packages]
     runs-on: [self-hosted, linux, ARM64]
     timeout-minutes: 1440
+    environment: rebuild-docker
     if: github.event_name == 'pull_request'
 
     # This strategy is used to run the job for each package that needs to be rebuilt. This allows multiple


### PR DESCRIPTION
This PR implements restrictions on who can trigger the `Deploy Autonomy` and `Rebuild Docker` GitHub Action Jobs within the Autonomy Software project. Due to the significant computing power required to run these actions, it is essential to limit access to only those with the appropriate permissions.

**Key Changes:**
- Permission Enforcement: Added role-based restrictions to the `Deploy Autonomy` and `Rebuild Docker` GitHub Action Jobs, ensuring that only authorized users, such as Admins or Maintainers, can initiate these resource-intensive workflows.
- Workflow Updates: Modified the YAML configurations for the affected actions to check for required permissions before execution.

**Benefits:**
- Resource Management: Helps prevent unnecessary or unauthorized consumption of computing resources by limiting access to high-demand workflows.
- Enhanced Security: Reduces the risk of accidental or unauthorized changes that could lead to resource overuse or system instability.
- Streamlined Workflow: Ensures that only qualified individuals can trigger these actions, reducing the potential for errors.

**Next Steps:**
- Monitor the impact of these restrictions on project workflow and resource usage.
- Evaluate if additional high-resource actions require similar access control.