### PR TITLE
Tag Detection Tweaks and State Machine Bug Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(NOT CTest_CMake_INCLUDED)
 endif()
 
 ## Enable or Disble Simulation Mode
-option(BUILD_SIM_MODE "Enable Simulation Mode" ON)
+option(BUILD_SIM_MODE "Enable Simulation Mode" OFF)
 if(BUILD_SIM_MODE)
     message("Sim Mode: Enabled")
     add_compile_definitions(__AUTONOMY_SIM_MODE__=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if(NOT CTest_CMake_INCLUDED)
 endif()
 
 ## Enable or Disble Simulation Mode
-option(BUILD_SIM_MODE "Enable Simulation Mode" OFF)
+option(BUILD_SIM_MODE "Enable Simulation Mode" ON)
 if(BUILD_SIM_MODE)
     message("Sim Mode: Enabled")
     add_compile_definitions(__AUTONOMY_SIM_MODE__=1)

--- a/src/drivers/MultimediaBoard.cpp
+++ b/src/drivers/MultimediaBoard.cpp
@@ -104,8 +104,6 @@ void MultimediaBoard::SendLightingState(MultimediaBoardLightingState eState)
         case MultimediaBoardLightingState::eReachedGoal:
         {
             // Send Reached Goal state over RoveComm.
-            // Construct a RoveComm packet.
-            rovecomm::RoveCommPacket<uint8_t> stPacket;
             stPacket.unDataId    = manifest::Autonomy::TELEMETRY.find("REACHEDGOAL")->second.DATA_ID;
             stPacket.unDataCount = manifest::Autonomy::TELEMETRY.find("REACHEDGOAL")->second.DATA_COUNT;
             stPacket.eDataType   = manifest::Autonomy::TELEMETRY.find("REACHEDGOAL")->second.DATA_TYPE;
@@ -117,6 +115,7 @@ void MultimediaBoard::SendLightingState(MultimediaBoardLightingState eState)
             stPacket.unDataId    = manifest::Core::COMMANDS.find("STATEDISPLAY")->second.DATA_ID;
             stPacket.unDataCount = manifest::Core::COMMANDS.find("STATEDISPLAY")->second.DATA_COUNT;
             stPacket.eDataType   = manifest::Core::COMMANDS.find("STATEDISPLAY")->second.DATA_TYPE;
+            stPacket.vData.clear();
             // Use RoveComm to send flashing GREEN color state value.
             stPacket.vData.emplace_back(static_cast<uint8_t>(manifest::Core::DISPLAYSTATE::REACHED_GOAL));
             break;

--- a/src/states/ApproachingMarkerState.cpp
+++ b/src/states/ApproachingMarkerState.cpp
@@ -275,7 +275,9 @@ namespace statemachine
             }
             case Event::eMarkerUnseen:
             {
+                // Submit logger message.
                 LOG_INFO(logging::g_qSharedLogger, "ApproachingMarkerState: Handling MarkerUnseen event.");
+                // Change states.
                 eNextState = m_eTriggeringState;
                 break;
             }

--- a/src/states/ApproachingMarkerState.h
+++ b/src/states/ApproachingMarkerState.h
@@ -36,6 +36,7 @@ namespace statemachine
         private:
             bool m_bInitialized;
 
+            States m_eTriggeringState;                       // The state that the rover was in before triggering the MarkerSeen event.
             int m_nNumDetectionAttempts;                     // Number of consecutive unsuccessful attempts to detect a tag.
             int m_nTargetTagID;                              // ID of the target tag.
             bool m_bDetected;                                // Has a target tag been detected and identified yet.

--- a/src/states/ApproachingObjectState.cpp
+++ b/src/states/ApproachingObjectState.cpp
@@ -100,7 +100,11 @@ namespace statemachine
         {
             case Event::eReachedObject:
             {
+                // Submit logger message.
                 LOG_INFO(logging::g_qSharedLogger, "ApproachingObjectState: Handling ReachedObject event.");
+                // Pop old waypoint out of queue.
+                globals::g_pWaypointHandler->PopNextWaypoint();
+                // Change state.
                 eNextState = States::eIdle;
                 break;
             }

--- a/src/states/NavigatingState.h
+++ b/src/states/NavigatingState.h
@@ -14,6 +14,7 @@
 #include "../interfaces/State.hpp"
 #include "../util/GeospatialOperations.hpp"
 #include "../util/states/StuckDetection.hpp"
+#include "../vision/aruco/TagDetector.h"
 
 /******************************************************************************
  * @brief Namespace containing all state machine related classes.
@@ -33,6 +34,9 @@ namespace statemachine
     class NavigatingState : public State
     {
         private:
+            /////////////////////////////////////////
+            // Declare private member variables.
+            /////////////////////////////////////////
             bool m_bFetchNewWaypoint;
             geoops::Waypoint m_stGoalWaypoint;
             int m_nMaxDataPoints;
@@ -41,13 +45,20 @@ namespace statemachine
             time_t m_tStuckCheckTime;
             double m_dStuckCheckLastPosition[2];
             bool m_bInitialized;
+            std::vector<TagDetector*> m_vTagDetectors;
             statemachine::TimeIntervalBasedStuckDetector m_StuckDetector;
 
         protected:
+            /////////////////////////////////////////
+            // Declare protected class methods.
+            /////////////////////////////////////////
             void Start() override;
             void Exit() override;
 
         public:
+            /////////////////////////////////////////
+            // Declare public class methods.
+            /////////////////////////////////////////
             NavigatingState();
             void Run() override;
             States TriggerEvent(Event eEvent) override;

--- a/src/states/SearchPatternState.cpp
+++ b/src/states/SearchPatternState.cpp
@@ -235,8 +235,6 @@ namespace statemachine
             {
                 // Submit logger message.
                 LOG_INFO(logging::g_qSharedLogger, "SearchPatternState: Handling MarkerSeen event.");
-                // Pop old waypoint out of queue.
-                globals::g_pWaypointHandler->PopNextWaypoint();
                 // Change states.
                 eNextState = States::eApproachingMarker;
                 break;
@@ -245,8 +243,6 @@ namespace statemachine
             {
                 // Submit logger message.
                 LOG_INFO(logging::g_qSharedLogger, "SearchPatternState: Handling ObjectSeen event.");
-                // Pop old waypoint out of queue.
-                globals::g_pWaypointHandler->PopNextWaypoint();
                 // Change state.
                 eNextState = States::eApproachingObject;
                 break;

--- a/src/states/VerifyingMarkerState.cpp
+++ b/src/states/VerifyingMarkerState.cpp
@@ -117,6 +117,8 @@ namespace statemachine
                 LOG_INFO(logging::g_qSharedLogger, "VerifyingMarkerState: Handling Verifying Complete event.");
                 // Send multimedia command to update state display.
                 globals::g_pMultimediaBoard->SendLightingState(MultimediaBoard::MultimediaBoardLightingState::eReachedGoal);
+                // Pop old waypoint out of queue.
+                globals::g_pWaypointHandler->PopNextWaypoint();
                 // Change state.
                 eNextState = States::eIdle;
                 break;

--- a/src/states/VerifyingObjectState.cpp
+++ b/src/states/VerifyingObjectState.cpp
@@ -118,6 +118,8 @@ namespace statemachine
                 LOG_INFO(logging::g_qSharedLogger, "VerifyingObjectState: Handling Verifying Complete event.");
                 // Send multimedia command to update state display.
                 globals::g_pMultimediaBoard->SendLightingState(MultimediaBoard::MultimediaBoardLightingState::eReachedGoal);
+                // Pop old waypoint out of queue.
+                globals::g_pWaypointHandler->PopNextWaypoint();
                 // Change state.
                 eNextState = States::eIdle;
                 break;

--- a/src/vision/aruco/TagDetector.h
+++ b/src/vision/aruco/TagDetector.h
@@ -132,6 +132,7 @@ class TagDetector : public AutonomyThread<void>
         // Create frames for storing images and point clouds.
 
         cv::Mat m_cvFrame;
+        cv::cuda::GpuMat m_cvGPUFrame;
         cv::Mat m_cvArucoProcFrame;
         cv::Mat m_cvTensorflowProcFrame;
         cv::Mat m_cvPointCloud;


### PR DESCRIPTION
## Tag Detection
- Change the TagDetector class to use the regular RGB image from the ZEDCam instead of the split PointCloud colors. This prevents the tag itself from being masked out at long distances due to bad depth information.

## State Machine
- Add tag detection to NavigatingState
- Fix the NavigatingState so that it doesn't pop waypoints. Only the verify state can.
- Fix approaching marker so that it goes back to the calling state instead of the SearchPatterState if the marker is unseen.

NOTE: ApproachingMarkerState currently doesn't use the VerifyingMarkerState. When this is eventually used, remove all PopNextWaypoint calls from the state.

## Other Changes
- Fix segfault from MultimediaBoard