### PR TITLE
[CRITICAL FIX] All Unit/Integration Tests Skipped

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,8 @@ jobs:
 
       - name: Check if the directory tests source exists
         run: |
-          DIRECTORY="test/${{ matrix.type }}/src"
+          BASE_DIR="/opt/Autonomy_Software"
+          DIRECTORY="$BASE_DIR/tests/${{ matrix.type }}/src"
 
           # Check if the directory exists
           if [ -d "$DIRECTORY" ]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,8 +54,7 @@ jobs:
 
       - name: Check if the directory tests source exists
         run: |
-          BASE_DIR="/opt/Autonomy_Software"
-          DIRECTORY="$BASE_DIR/tests/${{ matrix.type }}/src"
+          DIRECTORY="/opt/Autonomy_Software/tests/${{ matrix.type }}/src"
 
           # Check if the directory exists
           if [ -d "$DIRECTORY" ]; then


### PR DESCRIPTION
When logic was added to make sure that we weren't wasting compute time in the unit testing runners by skipping tests building tests if they don't exist in 57ad59f. The directory path to the tests directory was miss typed and not caught until now.

ClickUp: CU-8689nmmur