### PR TITLE
Update README.md and RoveComm to v25.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@
     <a href="https://github.com/MissouriMRDT/Autonomy_Software/actions/workflows/tests.yml">
       <img src="https://img.shields.io/github/actions/workflow/status/missourimrdt/autonomy_software/tests.yml?branch=development&label=Unit%20Tests&style=flat-round" alt="tests-ci" />
     </a>
-    <a href="https://github.com/MissouriMRDT/Autonomy_Software/actions/workflows/valgrind.yml">
-      <img src="https://img.shields.io/github/actions/workflow/status/missourimrdt/autonomy_software/valgrind.yml?branch=development&label=Valgrind&style=flat-round" alt="valgrind-ci" />
-    </a>
   </div>
 
   <div>


### PR DESCRIPTION
Remove Valgrind Action from README now that we have removed the workflow