### PR TITLE
Removed gfortran as it was not being used

### DIFF
--- a/.devcontainer/Jammy.dockerfile
+++ b/.devcontainer/Jammy.dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y iputils-ping \
     build-essential gdb less udev zstd sudo libgomp1 python-is-python3 \
     cmake git libgtk2.0-dev pkg-config libx264-dev libdrm-dev ssh \
     libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev tzdata net-tools \
-    yasm libatlas-base-dev gfortran libpq-dev libpostproc-dev libusb-1.0-0-dev \
+    yasm libatlas-base-dev libpq-dev libpostproc-dev libusb-1.0-0-dev \
     libxine2-dev libglew-dev libtiff5-dev zlib1g-dev cowsay lolcat locales usbutils \
     libeigen3-dev python3-dev python3-pip python3-numpy libx11-dev xauth libssl-dev \
     valgrind doxygen graphviz htop nano fortune fortunes gnuplot-nox \

--- a/.devcontainer/JetPack.dockerfile
+++ b/.devcontainer/JetPack.dockerfile
@@ -34,7 +34,7 @@ RUN apt update && apt install -y wget && \
 
 # Install Required Ubuntu Packages
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    build-essential gfortran cmake git gdb file tar libatlas-base-dev apt-transport-https iputils-ping \
+    build-essential cmake git gdb file tar libatlas-base-dev apt-transport-https iputils-ping \
     libswresample-dev libcanberra-gtk3-module zstd less libx264-dev libdrm-dev python-is-python3 \
     libeigen3-dev libglew-dev libgstreamer-plugins-base1.0-dev udev net-tools libssl-dev \
     libgstreamer-plugins-good1.0-dev libgstreamer1.0-dev libgtk-3-dev libjpeg-dev sudo usbutils \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,8 +40,8 @@
         "source=${localWorkspaceFolder}/data/calibrations/zed,target=/usr/local/zed/settings,type=bind,consistency=delegated",
         "type=bind,readonly,source=/etc/localtime,target=/etc/localtime"
     ],
-    "image": "ghcr.io/missourimrdt/autonomy-jammy:2025-04-19-04-17-28",
-    // "image": "ghcr.io/missourimrdt/autonomy-jetpack:2025-04-19-04-17-28",
+    "image": "ghcr.io/missourimrdt/autonomy-jammy:2025-05-08-03-09-25",
+    // "image": "ghcr.io/missourimrdt/autonomy-jetpack:2025-05-08-03-09-25",
     // "build": {
     //     "dockerfile": "Jammy.dockerfile"
     //     "dockerfile": "JetPack.dockerfile"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,7 @@ jobs:
           cd /opt/Autonomy_Software/
           rm -rf build && mkdir build && cd build
           cmake -DBUILD_TESTS_MODE=ON ..
-          make -j8
+          make -j1
 
           LABEL="${{ matrix.type == 'Unit' && 'UTest' || 'ITest' }}"
           ctest --output-on-failure -T Test -L "$LABEL" --output-junit "${LABEL}s.xml"


### PR DESCRIPTION
### **Description**
A removal of gfortran from the dockerfile as it is not used anywhere in the codebase and is thus not needed. 

### **Changes Made**
Removed `gfortran` from the jammy and jetPack dockerfiles APT installed packages. 

### **Additional Context**
Adam will hate this and say this PR is blasphemy.  
