### PR TITLE
Testing Mallet Detection (bug fixes and cleanup)

### DIFF
--- a/src/AutonomyConstants.cpp
+++ b/src/AutonomyConstants.cpp
@@ -74,8 +74,8 @@ namespace constants
     const float DRIVE_MAX_POWER = 1.0;     // Internally autonomy uses -1.0 to 1.0 for drive powers. But this range should be mapped to the actual drive board max range.
     const float DRIVE_MIN_POWER = -1.0;    // Internally autonomy uses -1.0 to 1.0 for drive powers. But this range should be mapped to the actual drive board min range.
     // NOTE: This should not be used to adjust the rover's speed for task. This is just a limit. Refer to the state machine constants for speed control.
-    const float DRIVE_MAX_EFFORT = 0.4;     // This is the max effort in the drive board's range that can be used to clamp/cutoff the drive power.
-    const float DRIVE_MIN_EFFORT = -0.4;    // This is the min effort in the drive board's range that can be used to clamp/cutoff the drive power.
+    const float DRIVE_MAX_EFFORT = 0.5;     // This is the max effort in the drive board's range that can be used to clamp/cutoff the drive power.
+    const float DRIVE_MIN_EFFORT = -0.5;    // This is the min effort in the drive board's range that can be used to clamp/cutoff the drive power.
 
     // Control constants.
     const double DRIVE_PID_PROPORTIONAL      = 0.015;    // The proportional gain for the controller used to point the rover at a goal heading during navigation.
@@ -261,7 +261,7 @@ namespace constants
     const double STATEMACHINE_ZED_REALIGN_THRESHOLD = 0.5;    // The threshold in meters that the error between GPS and ZED must be before realigning the ZED cameras.
 
     // Approaching Marker State
-    const double APPROACH_MARKER_MOTOR_POWER          = 0.35;    // The amount of power the motors use when approaching the marker.
+    const double APPROACH_MARKER_MOTOR_POWER          = DRIVE_MAX_EFFORT * 0.6;    // The amount of power the motors use when approaching the marker.
     const double APPROACH_MARKER_PROXIMITY_THRESHOLD  = 2.0;     // How close in meters the rover must be to the target marker before completing its approach.
     const double APPROACH_MARKER_LOST_GIVE_UP_TIME    = 15.0;    // The time in seconds to wait before giving up on the approach AFTER the tag is lost.
     const bool APPROACH_MARKER_VERIFY_POSITION        = true;    // Whether or not the rover should sit and watch the tag for a while before moving on.
@@ -269,7 +269,7 @@ namespace constants
     const double APPROACH_MARKER_TAG_LOST_BUFFER_TIME = 2.0;     // The time in seconds to wait before considering the tag lost. This is used to prevent false negatives.
 
     // Approaching Object State
-    const double APPROACH_OBJECT_MOTOR_POWER         = 0.35;    // The amount of power the motors use when approaching the marker.
+    const double APPROACH_OBJECT_MOTOR_POWER         = DRIVE_MAX_EFFORT * 0.6;    // The amount of power the motors use when approaching the marker.
     const double APPROACH_OBJECT_PROXIMITY_THRESHOLD = 2.0;     // How close in meters the rover must be to the target marker before completing its approach.
     const double APPROACH_OBJECT_LOST_GIVE_UP_TIME   = 15.0;    // The time in seconds to wait before giving up on the approach AFTER the tag is lost.
     const bool APPROACH_OBJECT_VERIFY_POSITION       = true;    // Whether or not the rover should sit and watch the tag for a while before moving on.
@@ -279,21 +279,21 @@ namespace constants
     // Stuck State
     const double STUCK_CHECK_INTERVAL        = 2.0;     // Period in seconds between consecutive checks of if the rover's rotating.
     const unsigned int STUCK_CHECK_ATTEMPTS  = 3;       // Max number of failed checks of the rover's rotation before next attempt.
-    const double STUCK_CHECK_ROT_THRESH      = 4.0;     // Minimum angular velocity required to consider the rover as actively rotating.
-    const double STUCK_CHECK_VEL_THRESH      = 0.2;     // Minimum velocity required to consider the rover as actively moving.
+    const double STUCK_CHECK_ROT_THRESH      = 1.0;     // Minimum angular velocity required to consider the rover as actively rotating.
+    const double STUCK_CHECK_VEL_THRESH      = 0.01;     // Minimum velocity required to consider the rover as actively moving.
     const double STUCK_SAME_POINT_PROXIMITY  = 1.0;     // Points within this proximity of another point are considered the same.
     const double STUCK_HEADING_ALIGN_TIMEOUT = 5.0;     // The timeout in seconds before the rover gives up aligning to a certain heading.
     const double STUCK_ALIGN_DEGREES         = 65.0;    // The amount to rotate/realign for rover after a failed attempt.
     const double STUCK_ALIGN_TOLERANCE       = 5.0;     // Degree tolerance before realignment is considered complete.
 
     // Reverse State.
-    const double REVERSE_MOTOR_POWER       = 0.3;     // The speed to drive backwards at.
+    const double REVERSE_MOTOR_POWER       = DRIVE_MAX_EFFORT * 0.6;     // The speed to drive backwards at.
     const double REVERSE_DISTANCE          = 3.0;     // The distance to reverse in meters.
     const double REVERSE_TIMEOUT_PER_METER = 5.0;     // Reverse state timeout in seconds for each meter reversed.
     const bool REVERSE_MAINTAIN_HEADING    = true;    // Whether or not the rover should maintain heading while reversing.
 
     // Search Pattern State
-    const double SEARCH_MOTOR_POWER          = 0.4;     // The amount of power the motors use when approaching the marker.
+    const double SEARCH_MOTOR_POWER          = DRIVE_MAX_EFFORT * 0.5;     // The amount of power the motors use when approaching the marker.
     const double SEARCH_ANGULAR_STEP_DEGREES = 57.0;    // The amount the angle is incremented in each iteration of the loop (degrees).
     const double SEARCH_SPIRAL_SPACING       = 1.0;     // The spacing between successive points in the spiral (meters).
     const double SEARCH_ZIGZAG_SPACING       = 4.0;     // The spacing between successive points in the zigzag (meters).
@@ -301,13 +301,13 @@ namespace constants
     const double SEARCH_WAYPOINT_PROXIMITY   = 2.0;     // How close a rover must be to a point to have it count as visited.
 
     // Navigating State.
-    const double NAVIGATING_MOTOR_POWER         = 0.4;      // The speed to drive at when navigating.
+    const double NAVIGATING_MOTOR_POWER         = DRIVE_MAX_EFFORT * 0.8;      // The speed to drive at when navigating.
     const double NAVIGATING_REACHED_GOAL_RADIUS = 2.0;      // The radius in meters that the rover should get to the goal waypoint.
     const bool NAVIGATING_VERIFY_POSITION       = false;    // Whether or not the rover should sit and verify the rover's GPS position before moving on.
     const double NAVIGATING_VERIFY_SAMPLE_TIME  = 30.0;     // The time in seconds to collect GPS points before verifying the rover's GPS position.
 
     // Avoidance State.
-    const double AVOIDANCE_STATE_MOTOR_POWER = 0.3;    // Drive speed of avoidance state
+    const double AVOIDANCE_STATE_MOTOR_POWER = DRIVE_MAX_EFFORT * 0.3;    // Drive speed of avoidance state
 
     ///////////////////////////////////////////////////////////////////////////
 

--- a/src/AutonomyConstants.cpp
+++ b/src/AutonomyConstants.cpp
@@ -262,49 +262,53 @@ namespace constants
 
     // Approaching Marker State
     const double APPROACH_MARKER_MOTOR_POWER          = DRIVE_MAX_EFFORT * 0.6;    // The amount of power the motors use when approaching the marker.
-    const double APPROACH_MARKER_PROXIMITY_THRESHOLD  = 2.0;     // How close in meters the rover must be to the target marker before completing its approach.
-    const double APPROACH_MARKER_LOST_GIVE_UP_TIME    = 15.0;    // The time in seconds to wait before giving up on the approach AFTER the tag is lost.
-    const bool APPROACH_MARKER_VERIFY_POSITION        = true;    // Whether or not the rover should sit and watch the tag for a while before moving on.
-    const double APPROACH_MARKER_VERIFY_TIME          = 5.0;     // The time in seconds to watch the tag before moving on.
-    const double APPROACH_MARKER_TAG_LOST_BUFFER_TIME = 2.0;     // The time in seconds to wait before considering the tag lost. This is used to prevent false negatives.
+    const double APPROACH_MARKER_PROXIMITY_THRESHOLD  = 2.0;      // How close in meters the rover must be to the target marker before completing its approach.
+    const double APPROACH_MARKER_LOST_GIVE_UP_TIME    = 15.0;     // The time in seconds to wait before giving up on the approach AFTER the tag is lost.
+    const bool APPROACH_MARKER_VERIFY_POSITION        = true;     // Whether or not the rover should sit and watch the tag for a while before moving on.
+    const double APPROACH_MARKER_VERIFY_TIME          = 5.0;      // The time in seconds to watch the tag before moving on.
+    const double APPROACH_MARKER_TAG_LOST_BUFFER_TIME = 2.0;      // The time in seconds to wait before considering the tag lost. This is used to prevent false negatives.
+    const bool APPROACH_MARKER_ENABLE_STUCK_DETECT    = false;    // Whether or not to enable the stuck detection algorithm when approaching a marker.
 
     // Approaching Object State
     const double APPROACH_OBJECT_MOTOR_POWER         = DRIVE_MAX_EFFORT * 0.6;    // The amount of power the motors use when approaching the marker.
-    const double APPROACH_OBJECT_PROXIMITY_THRESHOLD = 2.0;     // How close in meters the rover must be to the target marker before completing its approach.
-    const double APPROACH_OBJECT_LOST_GIVE_UP_TIME   = 15.0;    // The time in seconds to wait before giving up on the approach AFTER the tag is lost.
-    const bool APPROACH_OBJECT_VERIFY_POSITION       = true;    // Whether or not the rover should sit and watch the tag for a while before moving on.
-    const double APPROACH_OBJECT_VERIFY_TIME         = 5.0;     // The time in seconds to watch the tag before moving on.
-    const double APPROACH_OBJECT_LOST_BUFFER_TIME    = 2.0;     // The time in seconds to wait before considering the tag lost. This is used to prevent false negatives.
+    const double APPROACH_OBJECT_PROXIMITY_THRESHOLD = 2.0;      // How close in meters the rover must be to the target marker before completing its approach.
+    const double APPROACH_OBJECT_LOST_GIVE_UP_TIME   = 15.0;     // The time in seconds to wait before giving up on the approach AFTER the tag is lost.
+    const bool APPROACH_OBJECT_VERIFY_POSITION       = true;     // Whether or not the rover should sit and watch the tag for a while before moving on.
+    const double APPROACH_OBJECT_VERIFY_TIME         = 5.0;      // The time in seconds to watch the tag before moving on.
+    const double APPROACH_OBJECT_LOST_BUFFER_TIME    = 2.0;      // The time in seconds to wait before considering the tag lost. This is used to prevent false negatives.
+    const bool APPROACH_OBJECT_ENABLE_STUCK_DETECT   = false;    // Whether or not to enable the stuck detection algorithm when approaching a marker.
 
     // Stuck State
     const double STUCK_CHECK_INTERVAL        = 2.0;     // Period in seconds between consecutive checks of if the rover's rotating.
     const unsigned int STUCK_CHECK_ATTEMPTS  = 3;       // Max number of failed checks of the rover's rotation before next attempt.
     const double STUCK_CHECK_ROT_THRESH      = 1.0;     // Minimum angular velocity required to consider the rover as actively rotating.
-    const double STUCK_CHECK_VEL_THRESH      = 0.01;     // Minimum velocity required to consider the rover as actively moving.
+    const double STUCK_CHECK_VEL_THRESH      = 0.01;    // Minimum velocity required to consider the rover as actively moving.
     const double STUCK_SAME_POINT_PROXIMITY  = 1.0;     // Points within this proximity of another point are considered the same.
     const double STUCK_HEADING_ALIGN_TIMEOUT = 5.0;     // The timeout in seconds before the rover gives up aligning to a certain heading.
     const double STUCK_ALIGN_DEGREES         = 65.0;    // The amount to rotate/realign for rover after a failed attempt.
     const double STUCK_ALIGN_TOLERANCE       = 5.0;     // Degree tolerance before realignment is considered complete.
 
     // Reverse State.
-    const double REVERSE_MOTOR_POWER       = DRIVE_MAX_EFFORT * 0.6;     // The speed to drive backwards at.
-    const double REVERSE_DISTANCE          = 3.0;     // The distance to reverse in meters.
-    const double REVERSE_TIMEOUT_PER_METER = 5.0;     // Reverse state timeout in seconds for each meter reversed.
-    const bool REVERSE_MAINTAIN_HEADING    = true;    // Whether or not the rover should maintain heading while reversing.
+    const double REVERSE_MOTOR_POWER       = DRIVE_MAX_EFFORT * 0.6;    // The speed to drive backwards at.
+    const double REVERSE_DISTANCE          = 3.0;                       // The distance to reverse in meters.
+    const double REVERSE_TIMEOUT_PER_METER = 5.0;                       // Reverse state timeout in seconds for each meter reversed.
+    const bool REVERSE_MAINTAIN_HEADING    = true;                      // Whether or not the rover should maintain heading while reversing.
 
     // Search Pattern State
-    const double SEARCH_MOTOR_POWER          = DRIVE_MAX_EFFORT * 0.5;     // The amount of power the motors use when approaching the marker.
-    const double SEARCH_ANGULAR_STEP_DEGREES = 57.0;    // The amount the angle is incremented in each iteration of the loop (degrees).
-    const double SEARCH_SPIRAL_SPACING       = 1.0;     // The spacing between successive points in the spiral (meters).
-    const double SEARCH_ZIGZAG_SPACING       = 4.0;     // The spacing between successive points in the zigzag (meters).
-    const double SEARCH_SNAKE_SLITHERS       = 2.0;     // The number of slithers in the snake pattern.
-    const double SEARCH_WAYPOINT_PROXIMITY   = 2.0;     // How close a rover must be to a point to have it count as visited.
+    const double SEARCH_MOTOR_POWER          = DRIVE_MAX_EFFORT * 0.5;    // The amount of power the motors use when approaching the marker.
+    const double SEARCH_ANGULAR_STEP_DEGREES = 57.0;                      // The amount the angle is incremented in each iteration of the loop (degrees).
+    const double SEARCH_SPIRAL_SPACING       = 1.0;                       // The spacing between successive points in the spiral (meters).
+    const double SEARCH_ZIGZAG_SPACING       = 4.0;                       // The spacing between successive points in the zigzag (meters).
+    const double SEARCH_SNAKE_SLITHERS       = 2.0;                       // The number of slithers in the snake pattern.
+    const double SEARCH_WAYPOINT_PROXIMITY   = 2.0;                       // How close a rover must be to a point to have it count as visited.
+    const bool SEARCH_ENABLE_STUCK_DETECT    = false;                     // Whether or not to enable the stuck detection algorithm when searching for a marker.
 
     // Navigating State.
-    const double NAVIGATING_MOTOR_POWER         = DRIVE_MAX_EFFORT * 0.8;      // The speed to drive at when navigating.
-    const double NAVIGATING_REACHED_GOAL_RADIUS = 2.0;      // The radius in meters that the rover should get to the goal waypoint.
-    const bool NAVIGATING_VERIFY_POSITION       = false;    // Whether or not the rover should sit and verify the rover's GPS position before moving on.
-    const double NAVIGATING_VERIFY_SAMPLE_TIME  = 30.0;     // The time in seconds to collect GPS points before verifying the rover's GPS position.
+    const double NAVIGATING_MOTOR_POWER         = DRIVE_MAX_EFFORT * 0.8;    // The speed to drive at when navigating.
+    const double NAVIGATING_REACHED_GOAL_RADIUS = 2.0;                       // The radius in meters that the rover should get to the goal waypoint.
+    const bool NAVIGATING_VERIFY_POSITION       = false;                     // Whether or not the rover should sit and verify the rover's GPS position before moving on.
+    const double NAVIGATING_VERIFY_SAMPLE_TIME  = 30.0;                      // The time in seconds to collect GPS points before verifying the rover's GPS position.
+    const bool NAVIGATING_ENABLE_STUCK_DETECT   = false;                     // Whether or not to enable the stuck detection algorithm when navigating to a waypoint.
 
     // Avoidance State.
     const double AVOIDANCE_STATE_MOTOR_POWER = DRIVE_MAX_EFFORT * 0.3;    // Drive speed of avoidance state

--- a/src/AutonomyConstants.h
+++ b/src/AutonomyConstants.h
@@ -270,6 +270,7 @@ namespace constants
     extern const bool APPROACH_MARKER_VERIFY_POSITION;
     extern const double APPROACH_MARKER_VERIFY_TIME;
     extern const double APPROACH_MARKER_TAG_LOST_BUFFER_TIME;
+    extern const bool APPROACH_MARKER_ENABLE_STUCK_DETECT;
 
     // Approaching Object State
     extern const double APPROACH_OBJECT_MOTOR_POWER;
@@ -278,6 +279,7 @@ namespace constants
     extern const bool APPROACH_OBJECT_VERIFY_POSITION;
     extern const double APPROACH_OBJECT_VERIFY_TIME;
     extern const double APPROACH_OBJECT_LOST_BUFFER_TIME;
+    extern const bool APPROACH_OBJECT_ENABLE_STUCK_DETECT;
 
     // Stuck State
     extern const double STUCK_CHECK_INTERVAL;
@@ -302,12 +304,14 @@ namespace constants
     extern const double SEARCH_ZIGZAG_SPACING;
     extern const double SEARCH_SNAKE_SLITHERS;
     extern const double SEARCH_WAYPOINT_PROXIMITY;
+    extern const bool SEARCH_ENABLE_STUCK_DETECT;
 
     // Navigating State.
     extern const double NAVIGATING_MOTOR_POWER;
     extern const double NAVIGATING_REACHED_GOAL_RADIUS;
     extern const bool NAVIGATING_VERIFY_POSITION;
     extern const double NAVIGATING_VERIFY_SAMPLE_TIME;
+    extern const bool NAVIGATING_ENABLE_STUCK_DETECT;
 
     // Avoidance State.
     extern const double AVOIDANCE_STATE_MOTOR_POWER;

--- a/src/drivers/DriveBoard.cpp
+++ b/src/drivers/DriveBoard.cpp
@@ -127,11 +127,11 @@ void DriveBoard::SendDrive(const diffdrive::DrivePowers& stDrivePowers)
         double dLeftSpeed  = std::clamp(stDrivePowers.dLeftDrivePower, -1.0, 1.0);
         double dRightSpeed = std::clamp(stDrivePowers.dRightDrivePower, -1.0, 1.0);
         // Remap -1.0 - 1.0 range to drive power range defined in constants. This is so that the driveboard/rovecomm can understand our input.
-        fDriveBoardLeftPower  = numops::MapRange(float(dLeftSpeed), -1.0f, 1.0f, m_fMinDriveEffort, m_fMaxDriveEffort);
-        fDriveBoardRightPower = numops::MapRange(float(dRightSpeed), -1.0f, 1.0f, m_fMinDriveEffort, m_fMaxDriveEffort);
+        // fDriveBoardLeftPower  = numops::MapRange(float(dLeftSpeed), -1.0f, 1.0f, m_fMinDriveEffort, m_fMaxDriveEffort);
+        // fDriveBoardRightPower = numops::MapRange(float(dRightSpeed), -1.0f, 1.0f, m_fMinDriveEffort, m_fMaxDriveEffort);
         // Limit the power to max and min effort defined in constants.
-        fDriveBoardLeftPower  = std::clamp(float(fDriveBoardLeftPower), constants::DRIVE_MIN_POWER, constants::DRIVE_MAX_POWER);
-        fDriveBoardRightPower = std::clamp(float(fDriveBoardRightPower), constants::DRIVE_MIN_POWER, constants::DRIVE_MAX_POWER);
+        fDriveBoardLeftPower  = std::clamp(float(dLeftSpeed), constants::DRIVE_MIN_EFFORT, constants::DRIVE_MAX_EFFORT);
+        fDriveBoardRightPower = std::clamp(float(dRightSpeed), constants::DRIVE_MIN_EFFORT, constants::DRIVE_MAX_EFFORT);
         // Update member variables with new target speeds.
         m_stDrivePowers.dLeftDrivePower  = fDriveBoardLeftPower;
         m_stDrivePowers.dRightDrivePower = fDriveBoardRightPower;

--- a/src/drivers/DriveBoard.cpp
+++ b/src/drivers/DriveBoard.cpp
@@ -126,9 +126,6 @@ void DriveBoard::SendDrive(const diffdrive::DrivePowers& stDrivePowers)
         // Limit input values.
         double dLeftSpeed  = std::clamp(stDrivePowers.dLeftDrivePower, -1.0, 1.0);
         double dRightSpeed = std::clamp(stDrivePowers.dRightDrivePower, -1.0, 1.0);
-        // Remap -1.0 - 1.0 range to drive power range defined in constants. This is so that the driveboard/rovecomm can understand our input.
-        // fDriveBoardLeftPower  = numops::MapRange(float(dLeftSpeed), -1.0f, 1.0f, m_fMinDriveEffort, m_fMaxDriveEffort);
-        // fDriveBoardRightPower = numops::MapRange(float(dRightSpeed), -1.0f, 1.0f, m_fMinDriveEffort, m_fMaxDriveEffort);
         // Limit the power to max and min effort defined in constants.
         fDriveBoardLeftPower  = std::clamp(float(dLeftSpeed), constants::DRIVE_MIN_EFFORT, constants::DRIVE_MAX_EFFORT);
         fDriveBoardRightPower = std::clamp(float(dRightSpeed), constants::DRIVE_MIN_EFFORT, constants::DRIVE_MAX_EFFORT);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -239,7 +239,7 @@ int main()
         globals::g_pStateMachineHandler->StartStateMachine();
 
         // Create a vector of ints to store the FPS values for each thread.
-        std::vector<int> vThreadFPSValues;
+        std::vector<uint32_t> vThreadFPSValues;
 
         /*
             This while loop is the main periodic loop for the Autonomy_Software program.
@@ -249,13 +249,13 @@ int main()
         {
             // Add each threads FPS value to the vector.
             vThreadFPSValues.clear();
-            vThreadFPSValues.push_back(static_cast<int>(IterPerSecond.GetExactIPS()));
-            vThreadFPSValues.push_back(static_cast<int>(pMainCam->GetIPS().GetExactIPS()));
-            vThreadFPSValues.push_back(static_cast<int>(pMainTagDetector->GetIPS().GetExactIPS()));
-            vThreadFPSValues.push_back(static_cast<int>(pMainObjectDetector->GetIPS().GetExactIPS()));
-            vThreadFPSValues.push_back(static_cast<int>(globals::g_pStateMachineHandler->GetIPS().GetExactIPS()));
-            vThreadFPSValues.push_back(static_cast<int>(network::g_pRoveCommUDPNode->GetIPS().GetExactIPS()));
-            vThreadFPSValues.push_back(static_cast<int>(network::g_pRoveCommTCPNode->GetIPS().GetExactIPS()));
+            vThreadFPSValues.push_back(static_cast<uint32_t>(IterPerSecond.GetExactIPS()));
+            vThreadFPSValues.push_back(static_cast<uint32_t>(pMainCam->GetIPS().GetExactIPS()));
+            vThreadFPSValues.push_back(static_cast<uint32_t>(pMainTagDetector->GetIPS().GetExactIPS()));
+            vThreadFPSValues.push_back(static_cast<uint32_t>(pMainObjectDetector->GetIPS().GetExactIPS()));
+            vThreadFPSValues.push_back(static_cast<uint32_t>(globals::g_pStateMachineHandler->GetIPS().GetExactIPS()));
+            vThreadFPSValues.push_back(static_cast<uint32_t>(network::g_pRoveCommUDPNode->GetIPS().GetExactIPS()));
+            vThreadFPSValues.push_back(static_cast<uint32_t>(network::g_pRoveCommTCPNode->GetIPS().GetExactIPS()));
 
             // Create a string to append FPS values to.
             std::string szMainInfo = "";
@@ -429,17 +429,17 @@ int main()
             if (network::g_pRoveCommUDPNode)
             {
                 // Construct a RoveComm packet with the drive data.
-                rovecomm::RoveCommPacket<float> stPacket;
-                stPacket.unDataId    = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_ID;
-                stPacket.unDataCount = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_COUNT;
-                stPacket.eDataType   = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_TYPE;
+                rovecomm::RoveCommPacket<uint32_t> stPacket;
+                stPacket.unDataId    = manifest::Autonomy::TELEMETRY.find("THREADFPS")->second.DATA_ID;
+                stPacket.unDataCount = manifest::Autonomy::TELEMETRY.find("THREADFPS")->second.DATA_COUNT;
+                stPacket.eDataType   = manifest::Autonomy::TELEMETRY.find("THREADFPS")->second.DATA_TYPE;
                 // Create a static variable to act a counter/iterator for the FPS value to use.
-                static int nThreadFPSIndex = 0;
+                static uint32_t nThreadFPSIndex = 0;
                 // Check if the index is within bounds of the vector.
-                if (nThreadFPSIndex < static_cast<int>(vThreadFPSValues.size()))
+                if (nThreadFPSIndex < static_cast<uint32_t>(vThreadFPSValues.size()))
                 {
                     // First push back the thread enum identifier cast to an int.
-                    stPacket.vData.push_back(nThreadFPSIndex);
+                    stPacket.vData.push_back(nThreadFPSIndex + 1);
                     // Add the current FPS value to the packet data.
                     stPacket.vData.push_back(static_cast<float>(vThreadFPSValues[nThreadFPSIndex]));
                     // Increment the index for the next iteration.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -422,37 +422,37 @@ int main()
                 }
             }
 
-            // /////////////////////////////////////////
-            // // Send thread stats over RoveComm.
-            // /////////////////////////////////////////
-            // // Check if rovecomm is initialized and running.
-            // if (network::g_pRoveCommUDPNode)
-            // {
-            //     // Construct a RoveComm packet with the drive data.
-            //     rovecomm::RoveCommPacket<float> stPacket;
-            //     stPacket.unDataId    = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_ID;
-            //     stPacket.unDataCount = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_COUNT;
-            //     stPacket.eDataType   = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_TYPE;
-            //     // Create a static variable to act a counter/iterator for the FPS value to use.
-            //     static int nThreadFPSIndex = 0;
-            //     // Check if the index is within bounds of the vector.
-            //     if (nThreadFPSIndex < static_cast<int>(vThreadFPSValues.size()))
-            //     {
-            //         // First push back the thread enum identifier cast to an int.
-            //         stPacket.vData.push_back(nThreadFPSIndex);
-            //         // Add the current FPS value to the packet data.
-            //         stPacket.vData.push_back(static_cast<float>(vThreadFPSValues[nThreadFPSIndex]));
-            //         // Increment the index for the next iteration.
-            //         nThreadFPSIndex++;
-            //     }
-            //     else
-            //     {
-            //         // Reset the index if it exceeds the vector size.
-            //         nThreadFPSIndex = 0;
-            //     }
-            //     // Send the packet over RoveComm UDP.
-            //     network::g_pRoveCommUDPNode->SendUDPPacket(stPacket, "0.0.0.0", constants::ROVECOMM_OUTGOING_UDP_PORT);
-            // }
+            /////////////////////////////////////////
+            // Send thread stats over RoveComm.
+            /////////////////////////////////////////
+            // Check if rovecomm is initialized and running.
+            if (network::g_pRoveCommUDPNode)
+            {
+                // Construct a RoveComm packet with the drive data.
+                rovecomm::RoveCommPacket<float> stPacket;
+                stPacket.unDataId    = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_ID;
+                stPacket.unDataCount = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_COUNT;
+                stPacket.eDataType   = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_TYPE;
+                // Create a static variable to act a counter/iterator for the FPS value to use.
+                static int nThreadFPSIndex = 0;
+                // Check if the index is within bounds of the vector.
+                if (nThreadFPSIndex < static_cast<int>(vThreadFPSValues.size()))
+                {
+                    // First push back the thread enum identifier cast to an int.
+                    stPacket.vData.push_back(nThreadFPSIndex);
+                    // Add the current FPS value to the packet data.
+                    stPacket.vData.push_back(static_cast<float>(vThreadFPSValues[nThreadFPSIndex]));
+                    // Increment the index for the next iteration.
+                    nThreadFPSIndex++;
+                }
+                else
+                {
+                    // Reset the index if it exceeds the vector size.
+                    nThreadFPSIndex = 0;
+                }
+                // Send the packet over RoveComm UDP.
+                network::g_pRoveCommUDPNode->SendUDPPacket(stPacket, "0.0.0.0", constants::ROVECOMM_OUTGOING_UDP_PORT);
+            }
 
             // Update IPS tick.
             IterPerSecond.Tick();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -403,7 +403,7 @@ int main()
                             }
                             else
                             {
-                                ossTagsInfo << "No valid Torch tags detected.\n";
+                                ossTagsInfo << "No valid Torch objects detected.\n";
                             }
 
                             LOG_NOTICE(logging::g_qSharedLogger, "{}", ossTagsInfo.str());
@@ -422,37 +422,37 @@ int main()
                 }
             }
 
-            /////////////////////////////////////////
-            // Send thread stats over RoveComm.
-            /////////////////////////////////////////
-            // Check if rovecomm is initialized and running.
-            if (network::g_pRoveCommUDPNode)
-            {
-                // Construct a RoveComm packet with the drive data.
-                rovecomm::RoveCommPacket<float> stPacket;
-                stPacket.unDataId    = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_ID;
-                stPacket.unDataCount = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_COUNT;
-                stPacket.eDataType   = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_TYPE;
-                // Create a static variable to act a counter/iterator for the FPS value to use.
-                static int nThreadFPSIndex = 0;
-                // Check if the index is within bounds of the vector.
-                if (nThreadFPSIndex < static_cast<int>(vThreadFPSValues.size()))
-                {
-                    // First push back the thread enum identifier cast to an int.
-                    stPacket.vData.push_back(nThreadFPSIndex);
-                    // Add the current FPS value to the packet data.
-                    stPacket.vData.push_back(static_cast<float>(vThreadFPSValues[nThreadFPSIndex]));
-                    // Increment the index for the next iteration.
-                    nThreadFPSIndex++;
-                }
-                else
-                {
-                    // Reset the index if it exceeds the vector size.
-                    nThreadFPSIndex = 0;
-                }
-                // Send the packet over RoveComm UDP.
-                network::g_pRoveCommUDPNode->SendUDPPacket(stPacket, "0.0.0.0", constants::ROVECOMM_OUTGOING_UDP_PORT);
-            }
+            // /////////////////////////////////////////
+            // // Send thread stats over RoveComm.
+            // /////////////////////////////////////////
+            // // Check if rovecomm is initialized and running.
+            // if (network::g_pRoveCommUDPNode)
+            // {
+            //     // Construct a RoveComm packet with the drive data.
+            //     rovecomm::RoveCommPacket<float> stPacket;
+            //     stPacket.unDataId    = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_ID;
+            //     stPacket.unDataCount = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_COUNT;
+            //     stPacket.eDataType   = manifest::Core::TELEMETRY.find("THREADFPS")->second.DATA_TYPE;
+            //     // Create a static variable to act a counter/iterator for the FPS value to use.
+            //     static int nThreadFPSIndex = 0;
+            //     // Check if the index is within bounds of the vector.
+            //     if (nThreadFPSIndex < static_cast<int>(vThreadFPSValues.size()))
+            //     {
+            //         // First push back the thread enum identifier cast to an int.
+            //         stPacket.vData.push_back(nThreadFPSIndex);
+            //         // Add the current FPS value to the packet data.
+            //         stPacket.vData.push_back(static_cast<float>(vThreadFPSValues[nThreadFPSIndex]));
+            //         // Increment the index for the next iteration.
+            //         nThreadFPSIndex++;
+            //     }
+            //     else
+            //     {
+            //         // Reset the index if it exceeds the vector size.
+            //         nThreadFPSIndex = 0;
+            //     }
+            //     // Send the packet over RoveComm UDP.
+            //     network::g_pRoveCommUDPNode->SendUDPPacket(stPacket, "0.0.0.0", constants::ROVECOMM_OUTGOING_UDP_PORT);
+            // }
 
             // Update IPS tick.
             IterPerSecond.Tick();

--- a/src/states/ApproachingMarkerState.cpp
+++ b/src/states/ApproachingMarkerState.cpp
@@ -290,15 +290,16 @@ namespace statemachine
         //////////////////////////////////////////
 
         // Check if stuck.
-        // if (m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
-        // {
-        //     // Submit logger message.
-        //     LOG_NOTICE(logging::g_qSharedLogger, "ApproachingMarkerState: Rover has become stuck!");
-        //     // Handle state transition and save the current search pattern state.
-        //     globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
-        //     // Don't execute the rest of the state.
-        //     return;
-        // }
+        if (constants::APPROACH_MARKER_ENABLE_STUCK_DETECT &&
+            m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
+        {
+            // Submit logger message.
+            LOG_NOTICE(logging::g_qSharedLogger, "ApproachingMarkerState: Rover has become stuck!");
+            // Handle state transition and save the current search pattern state.
+            globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
+            // Don't execute the rest of the state.
+            return;
+        }
 
         return;
     }

--- a/src/states/ApproachingMarkerState.cpp
+++ b/src/states/ApproachingMarkerState.cpp
@@ -290,15 +290,15 @@ namespace statemachine
         //////////////////////////////////////////
 
         // Check if stuck.
-        if (m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
-        {
-            // Submit logger message.
-            LOG_NOTICE(logging::g_qSharedLogger, "ApproachingMarkerState: Rover has become stuck!");
-            // Handle state transition and save the current search pattern state.
-            globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
-            // Don't execute the rest of the state.
-            return;
-        }
+        // if (m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
+        // {
+        //     // Submit logger message.
+        //     LOG_NOTICE(logging::g_qSharedLogger, "ApproachingMarkerState: Rover has become stuck!");
+        //     // Handle state transition and save the current search pattern state.
+        //     globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
+        //     // Don't execute the rest of the state.
+        //     return;
+        // }
 
         return;
     }

--- a/src/states/ApproachingObjectState.cpp
+++ b/src/states/ApproachingObjectState.cpp
@@ -248,15 +248,15 @@ namespace statemachine
         //////////////////////////////////////////
 
         // Check if stuck.
-        if (m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
-        {
-            // Submit logger message.
-            LOG_NOTICE(logging::g_qSharedLogger, "ApproachingObjectState: Rover has become stuck!");
-            // Handle state transition and save the current search pattern state.
-            globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
-            // Don't execute the rest of the state.
-            return;
-        }
+        // if (m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
+        // {
+        //     // Submit logger message.
+        //     LOG_NOTICE(logging::g_qSharedLogger, "ApproachingObjectState: Rover has become stuck!");
+        //     // Handle state transition and save the current search pattern state.
+        //     globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
+        //     // Don't execute the rest of the state.
+        //     return;
+        // }
 
         return;
     }

--- a/src/states/ApproachingObjectState.cpp
+++ b/src/states/ApproachingObjectState.cpp
@@ -248,15 +248,16 @@ namespace statemachine
         //////////////////////////////////////////
 
         // Check if stuck.
-        // if (m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
-        // {
-        //     // Submit logger message.
-        //     LOG_NOTICE(logging::g_qSharedLogger, "ApproachingObjectState: Rover has become stuck!");
-        //     // Handle state transition and save the current search pattern state.
-        //     globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
-        //     // Don't execute the rest of the state.
-        //     return;
-        // }
+        if (constants::APPROACH_OBJECT_ENABLE_STUCK_DETECT &&
+            m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
+        {
+            // Submit logger message.
+            LOG_NOTICE(logging::g_qSharedLogger, "ApproachingObjectState: Rover has become stuck!");
+            // Handle state transition and save the current search pattern state.
+            globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
+            // Don't execute the rest of the state.
+            return;
+        }
 
         return;
     }

--- a/src/states/NavigatingState.cpp
+++ b/src/states/NavigatingState.cpp
@@ -170,16 +170,16 @@ namespace statemachine
         {
             // NOTE: Optional - Uncomment the above code and comment out the below code to use stanley control to navigate to the goal waypoint.
             // Use stanley to calculate drive move/powers.
-            controllers::PredictiveStanleyController::DriveVector stDriveVector = m_pStanleyController->Calculate(stCurrentRoverPose);
-            // Calculate move from goal heading and desired speed.
-            diffdrive::DrivePowers stDriveSpeeds = globals::g_pDriveBoard->CalculateMove(stDriveVector.dVelocity,
-                                                                                         stDriveVector.dThetaHeading,
-                                                                                         stCurrentRoverPose.GetCompassHeading(),
-                                                                                         diffdrive::DifferentialControlMethod::eArcadeDrive);
-            // diffdrive::DrivePowers stDriveSpeeds = globals::g_pDriveBoard->CalculateMove(constants::NAVIGATING_MOTOR_POWER,
-            //                                                                              stGoalWaypointMeasurement.dStartRelativeBearing,
+            // controllers::PredictiveStanleyController::DriveVector stDriveVector = m_pStanleyController->Calculate(stCurrentRoverPose);
+            // // Calculate move from goal heading and desired speed.
+            // diffdrive::DrivePowers stDriveSpeeds = globals::g_pDriveBoard->CalculateMove(stDriveVector.dVelocity,
+            //                                                                              stDriveVector.dThetaHeading,
             //                                                                              stCurrentRoverPose.GetCompassHeading(),
             //                                                                              diffdrive::DifferentialControlMethod::eArcadeDrive);
+            diffdrive::DrivePowers stDriveSpeeds = globals::g_pDriveBoard->CalculateMove(constants::NAVIGATING_MOTOR_POWER,
+                                                                                         stGoalWaypointMeasurement.dStartRelativeBearing,
+                                                                                         stCurrentRoverPose.GetCompassHeading(),
+                                                                                         diffdrive::DifferentialControlMethod::eArcadeDrive);
             // Send drive powers over RoveComm.
             globals::g_pDriveBoard->SendDrive(stDriveSpeeds);
         }
@@ -309,15 +309,15 @@ namespace statemachine
         //////////////////////////////////////////
 
         // Check if stuck.
-        if (m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
-        {
-            // Submit logger message.
-            LOG_NOTICE(logging::g_qSharedLogger, "NavigatingState: Rover has become stuck!");
-            // Handle state transition and save the current search pattern state.
-            globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
-            // Don't execute the rest of the state.
-            return;
-        }
+        // if (m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
+        // {
+        //     // Submit logger message.
+        //     LOG_NOTICE(logging::g_qSharedLogger, "NavigatingState: Rover has become stuck!");
+        //     // Handle state transition and save the current search pattern state.
+        //     globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
+        //     // Don't execute the rest of the state.
+        //     return;
+        // }
     }
 
     /******************************************************************************

--- a/src/states/NavigatingState.cpp
+++ b/src/states/NavigatingState.cpp
@@ -309,15 +309,16 @@ namespace statemachine
         //////////////////////////////////////////
 
         // Check if stuck.
-        // if (m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
-        // {
-        //     // Submit logger message.
-        //     LOG_NOTICE(logging::g_qSharedLogger, "NavigatingState: Rover has become stuck!");
-        //     // Handle state transition and save the current search pattern state.
-        //     globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
-        //     // Don't execute the rest of the state.
-        //     return;
-        // }
+        if (constants::NAVIGATING_ENABLE_STUCK_DETECT &&
+            m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
+        {
+            // Submit logger message.
+            LOG_NOTICE(logging::g_qSharedLogger, "NavigatingState: Rover has become stuck!");
+            // Handle state transition and save the current search pattern state.
+            globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
+            // Don't execute the rest of the state.
+            return;
+        }
     }
 
     /******************************************************************************

--- a/src/states/SearchPatternState.cpp
+++ b/src/states/SearchPatternState.cpp
@@ -217,22 +217,22 @@ namespace statemachine
         //////////////////////////////////////////
 
         // Check if stuck.
-        if (m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
-        {
-            // Submit logger message.
-            LOG_WARNING(logging::g_qSharedLogger, "SearchPattern: Rover has become stuck!");
-            // Increment search path index so we skip the waypoint where we got stuck when reentering searchpattern.
-            m_nSearchPathIdx += 1;
-            // Check path index is within bounds.
-            if (m_nSearchPathIdx >= int(m_vSearchPath.size()))
-            {
-                m_nSearchPathIdx = m_vSearchPath.size() - 1;
-            }
-            // Handle state transition and save the current search pattern state.
-            globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
-            // Don't execute the rest of the state.
-            return;
-        }
+        // if (m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
+        // {
+        //     // Submit logger message.
+        //     LOG_WARNING(logging::g_qSharedLogger, "SearchPattern: Rover has become stuck!");
+        //     // Increment search path index so we skip the waypoint where we got stuck when reentering searchpattern.
+        //     m_nSearchPathIdx += 1;
+        //     // Check path index is within bounds.
+        //     if (m_nSearchPathIdx >= int(m_vSearchPath.size()))
+        //     {
+        //         m_nSearchPathIdx = m_vSearchPath.size() - 1;
+        //     }
+        //     // Handle state transition and save the current search pattern state.
+        //     globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
+        //     // Don't execute the rest of the state.
+        //     return;
+        // }
 
         ///////////////////////////////////
         /* --- Follow Search Pattern --- */

--- a/src/states/SearchPatternState.cpp
+++ b/src/states/SearchPatternState.cpp
@@ -217,22 +217,23 @@ namespace statemachine
         //////////////////////////////////////////
 
         // Check if stuck.
-        // if (m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
-        // {
-        //     // Submit logger message.
-        //     LOG_WARNING(logging::g_qSharedLogger, "SearchPattern: Rover has become stuck!");
-        //     // Increment search path index so we skip the waypoint where we got stuck when reentering searchpattern.
-        //     m_nSearchPathIdx += 1;
-        //     // Check path index is within bounds.
-        //     if (m_nSearchPathIdx >= int(m_vSearchPath.size()))
-        //     {
-        //         m_nSearchPathIdx = m_vSearchPath.size() - 1;
-        //     }
-        //     // Handle state transition and save the current search pattern state.
-        //     globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
-        //     // Don't execute the rest of the state.
-        //     return;
-        // }
+        if (constants::SEARCH_ENABLE_STUCK_DETECT &&
+            m_StuckDetector.CheckIfStuck(globals::g_pWaypointHandler->SmartRetrieveVelocity(), globals::g_pWaypointHandler->SmartRetrieveAngularVelocity()))
+        {
+            // Submit logger message.
+            LOG_WARNING(logging::g_qSharedLogger, "SearchPattern: Rover has become stuck!");
+            // Increment search path index so we skip the waypoint where we got stuck when reentering searchpattern.
+            m_nSearchPathIdx += 1;
+            // Check path index is within bounds.
+            if (m_nSearchPathIdx >= int(m_vSearchPath.size()))
+            {
+                m_nSearchPathIdx = m_vSearchPath.size() - 1;
+            }
+            // Handle state transition and save the current search pattern state.
+            globals::g_pStateMachineHandler->HandleEvent(Event::eStuck, true);
+            // Don't execute the rest of the state.
+            return;
+        }
 
         ///////////////////////////////////
         /* --- Follow Search Pattern --- */

--- a/src/states/SearchPatternState.cpp
+++ b/src/states/SearchPatternState.cpp
@@ -57,7 +57,7 @@ namespace statemachine
         m_pRoverPathPlot->CreateDotLayer("SnakeSearchPattern", "-g");
         m_pRoverPathPlot->CreateDotLayer("VerticalZigZagSearchPattern", "yellow");
         m_pRoverPathPlot->CreateDotLayer("DetectedTags", "blue");
-        m_pRoverPathPlot->CreateDotLayer("DetectedObjects", "red");
+        m_pRoverPathPlot->CreateDotLayer("DetectedObjects", "purple");
         m_pRoverPathPlot->CreatePathLayer("RoverPath", "-.r*");
         // Plot the search path on the rover path.
         m_pRoverPathPlot->AddPathPoints(m_vSearchPath, "SpiralSearchPattern", 0);
@@ -193,7 +193,7 @@ namespace statemachine
                 LOG_NOTICE(logging::g_qSharedLogger, "SearchPatternState: Rover has seen a target object!");
 
                 // Check if the torch tag has a good absolute position.
-                if (stBestTorchObject.dConfidence != 0.0 && stBestTorchObject.stGeolocatedPosition.eType == geoops::WaypointType::eTagWaypoint)
+                if (stBestTorchObject.dConfidence != 0.0 && stBestTorchObject.stGeolocatedPosition.eType == geoops::WaypointType::eObjectWaypoint)
                 {
                     // Add the tag to the path plot.
                     m_pRoverPathPlot->AddDot(stBestTorchObject.stGeolocatedPosition.GetUTMCoordinate(), "DetectedObjects");

--- a/src/states/VerifyingObjectState.cpp
+++ b/src/states/VerifyingObjectState.cpp
@@ -182,6 +182,16 @@ namespace statemachine
                 eNextState = States::eIdle;
                 break;
             }
+            case Event::eVerifyingFailed:
+            {
+                // Submit logger message.
+                LOG_INFO(logging::g_qSharedLogger, "VerifyingObjectState: Handling Verifying Failed event.");
+                // Send multimedia command to update state display.
+                globals::g_pMultimediaBoard->SendLightingState(MultimediaBoard::MultimediaBoardLightingState::eAutonomy);
+                // Recall the previous state.
+                eNextState = globals::g_pStateMachineHandler->GetPreviousState();
+                break;
+            }
             case Event::eAbort:
             {
                 // Submit logger message.

--- a/src/vision/aruco/TagDetector.cpp
+++ b/src/vision/aruco/TagDetector.cpp
@@ -336,7 +336,7 @@ void TagDetector::ThreadedContinuousCode()
         if (m_bTorchEnabled)
         {
             // Drop the Alpha channel from the image copy to preproc frame.
-            cv::cvtColor(m_cvFrame, m_cvTorchProcFrame, cv::COLOR_BGRA2RGB);
+            cv::cvtColor(m_cvFrame, m_cvTorchProcFrame, cv::COLOR_BGRA2BGR);
             // Detect tags in the image.
             std::vector<tagdetectutils::ArucoTag> vNewTorchTags =
                 torchtag::Detect(m_cvTorchProcFrame, *m_pTorchDetector, m_fTorchMinObjectConfidence, m_fTorchNMSThreshold);

--- a/src/vision/aruco/TagDetector.cpp
+++ b/src/vision/aruco/TagDetector.cpp
@@ -322,12 +322,8 @@ void TagDetector::ThreadedContinuousCode()
 
         // Clear the list of newly detected tags.
         m_vNewlyDetectedTags.clear();
-        // Run image through some pre-processing step to improve detection.
-        // NOTE: I disabled this since it was just converting to grayscale and isn't strictly necessary. - Clayton
-        // arucotag::PreprocessFrame(m_cvFrame, m_cvArucoProcFrame);
         // Copy the camera frame to the pre-processing frame.
         m_cvArucoProcFrame = m_cvFrame.clone();
-        m_cvTorchProcFrame = m_cvFrame.clone();
         // Detect tags in the image
         std::vector<tagdetectutils::ArucoTag> vNewOpenCVTags = arucotag::Detect(m_cvArucoProcFrame, m_cvArucoDetector);
         // Add OpenCV tags to the list of newly detected tags.
@@ -338,7 +334,7 @@ void TagDetector::ThreadedContinuousCode()
         {
             // Detect tags in the image.
             std::vector<tagdetectutils::ArucoTag> vNewTorchTags =
-                torchtag::Detect(m_cvTorchProcFrame, *m_pTorchDetector, m_fTorchMinObjectConfidence, m_fTorchNMSThreshold);
+                torchtag::Detect(m_cvArucoProcFrame, *m_pTorchDetector, m_fTorchMinObjectConfidence, m_fTorchNMSThreshold);
             // Add Torch tags to the list of newly detected tags.
             m_vNewlyDetectedTags.insert(m_vNewlyDetectedTags.end(), vNewTorchTags.begin(), vNewTorchTags.end());
         }

--- a/src/vision/aruco/TagDetector.cpp
+++ b/src/vision/aruco/TagDetector.cpp
@@ -336,7 +336,7 @@ void TagDetector::ThreadedContinuousCode()
         if (m_bTorchEnabled)
         {
             // Drop the Alpha channel from the image copy to preproc frame.
-            cv::cvtColor(m_cvFrame, m_cvTorchProcFrame, cv::COLOR_BGRA2BGR);
+            cv::cvtColor(m_cvFrame, m_cvTorchProcFrame, cv::COLOR_BGRA2RGB);
             // Detect tags in the image.
             std::vector<tagdetectutils::ArucoTag> vNewTorchTags =
                 torchtag::Detect(m_cvTorchProcFrame, *m_pTorchDetector, m_fTorchMinObjectConfidence, m_fTorchNMSThreshold);

--- a/src/vision/aruco/TagDetector.cpp
+++ b/src/vision/aruco/TagDetector.cpp
@@ -327,6 +327,7 @@ void TagDetector::ThreadedContinuousCode()
         // arucotag::PreprocessFrame(m_cvFrame, m_cvArucoProcFrame);
         // Copy the camera frame to the pre-processing frame.
         m_cvArucoProcFrame = m_cvFrame.clone();
+        m_cvTorchProcFrame = m_cvFrame.clone();
         // Detect tags in the image
         std::vector<tagdetectutils::ArucoTag> vNewOpenCVTags = arucotag::Detect(m_cvArucoProcFrame, m_cvArucoDetector);
         // Add OpenCV tags to the list of newly detected tags.
@@ -335,8 +336,6 @@ void TagDetector::ThreadedContinuousCode()
         // Check if torch detection if turned on.
         if (m_bTorchEnabled)
         {
-            // Drop the Alpha channel from the image copy to preproc frame.
-            cv::cvtColor(m_cvFrame, m_cvTorchProcFrame, cv::COLOR_BGRA2RGB);
             // Detect tags in the image.
             std::vector<tagdetectutils::ArucoTag> vNewTorchTags =
                 torchtag::Detect(m_cvTorchProcFrame, *m_pTorchDetector, m_fTorchMinObjectConfidence, m_fTorchNMSThreshold);

--- a/src/vision/aruco/TagDetector.h
+++ b/src/vision/aruco/TagDetector.h
@@ -140,7 +140,6 @@ class TagDetector : public AutonomyThread<void>
         cv::Mat m_cvFrame;
         cv::cuda::GpuMat m_cvGPUFrame;
         cv::Mat m_cvArucoProcFrame;
-        cv::Mat m_cvTorchProcFrame;
         cv::Mat m_cvPointCloud;
         cv::cuda::GpuMat m_cvGPUPointCloud;
 

--- a/src/vision/objects/ObjectDetector.cpp
+++ b/src/vision/objects/ObjectDetector.cpp
@@ -289,8 +289,7 @@ void ObjectDetector::ThreadedContinuousCode()
         // Clear the list of newly detected objects.
         m_vNewlyDetectedObjects.clear();
         // Copy the camera frame to the pre-processing frame and overlay frame.
-        m_cvTorchOverlayFrame = m_cvFrame.clone();
-        m_cvTorchProcFrame    = m_cvFrame.clone();
+        m_cvTorchProcFrame = m_cvFrame.clone();
 
         // Check if torch detection if turned on.
         if (m_bTorchEnabled)
@@ -313,7 +312,7 @@ void ObjectDetector::ThreadedContinuousCode()
         this->UpdateDetectedObjects(m_vNewlyDetectedObjects);
 
         // Draw object overlays onto normal image.
-        torchobject::DrawDetections(m_cvTorchOverlayFrame, m_vDetectedObjects);
+        torchobject::DrawDetections(m_cvTorchProcFrame, m_vDetectedObjects);
         /////////////////////////////////////////////////////////////////////////////////////
     }
 

--- a/src/vision/objects/ObjectDetector.cpp
+++ b/src/vision/objects/ObjectDetector.cpp
@@ -289,8 +289,7 @@ void ObjectDetector::ThreadedContinuousCode()
         // Clear the list of newly detected objects.
         m_vNewlyDetectedObjects.clear();
         // Copy the camera frame to the pre-processing frame and overlay frame.
-        m_cvTorchProcFrame    = m_cvFrame.clone();
-        m_cvTorchOverlayFrame = m_cvFrame.clone();
+        m_cvTorchProcFrame = m_cvFrame.clone();
 
         // Check if torch detection if turned on.
         if (m_bTorchEnabled)
@@ -315,7 +314,7 @@ void ObjectDetector::ThreadedContinuousCode()
         this->UpdateDetectedObjects(m_vNewlyDetectedObjects);
 
         // Draw object overlays onto normal image.
-        torchobject::DrawDetections(m_cvTorchOverlayFrame, m_vDetectedObjects);
+        torchobject::DrawDetections(m_cvTorchProcFrame, m_vDetectedObjects);
         /////////////////////////////////////////////////////////////////////////////////////
     }
 
@@ -363,8 +362,8 @@ void ObjectDetector::PooledLinearCode()
         // Check which frame we should copy.
         switch (stContainer.eFrameType)
         {
-            case PIXEL_FORMATS::eObjectDetection: *stContainer.pFrame = m_cvTorchOverlayFrame.clone(); break;
-            default: *stContainer.pFrame = m_cvTorchOverlayFrame.clone(); break;
+            case PIXEL_FORMATS::eObjectDetection: *stContainer.pFrame = m_cvTorchProcFrame.clone(); break;
+            default: *stContainer.pFrame = m_cvTorchProcFrame.clone(); break;
         }
 
         // Signal future that the frame has been successfully retrieved.

--- a/src/vision/objects/ObjectDetector.cpp
+++ b/src/vision/objects/ObjectDetector.cpp
@@ -296,7 +296,7 @@ void ObjectDetector::ThreadedContinuousCode()
         if (m_bTorchEnabled)
         {
             // Drop the Alpha channel from the image copy to preproc frame.
-            cv::cvtColor(m_cvFrame, m_cvTorchProcFrame, cv::COLOR_BGRA2RGB);
+            cv::cvtColor(m_cvFrame, m_cvTorchProcFrame, cv::COLOR_BGRA2BGR);
             // Detect objects in the image.
             std::vector<objectdetectutils::Object> vNewTorchObjects =
                 torchobject::Detect(m_cvTorchProcFrame, *m_pTorchDetector, m_fTorchMinObjectConfidence, m_fTorchNMSThreshold);

--- a/src/vision/objects/ObjectDetector.cpp
+++ b/src/vision/objects/ObjectDetector.cpp
@@ -290,12 +290,11 @@ void ObjectDetector::ThreadedContinuousCode()
         m_vNewlyDetectedObjects.clear();
         // Copy the camera frame to the pre-processing frame and overlay frame.
         m_cvTorchOverlayFrame = m_cvFrame.clone();
+        m_cvTorchProcFrame    = m_cvFrame.clone();
 
         // Check if torch detection if turned on.
         if (m_bTorchEnabled)
         {
-            // Drop the Alpha channel from the image copy to preproc frame.
-            cv::cvtColor(m_cvFrame, m_cvTorchProcFrame, cv::COLOR_BGRA2RGB);
             // Detect objects in the image.
             std::vector<objectdetectutils::Object> vNewTorchObjects =
                 torchobject::Detect(m_cvTorchProcFrame, *m_pTorchDetector, m_fTorchMinObjectConfidence, m_fTorchNMSThreshold);

--- a/src/vision/objects/ObjectDetector.cpp
+++ b/src/vision/objects/ObjectDetector.cpp
@@ -289,13 +289,13 @@ void ObjectDetector::ThreadedContinuousCode()
         // Clear the list of newly detected objects.
         m_vNewlyDetectedObjects.clear();
         // Copy the camera frame to the pre-processing frame and overlay frame.
-        m_cvTorchProcFrame = m_cvFrame.clone();
+        m_cvTorchOverlayFrame = m_cvFrame.clone();
 
         // Check if torch detection if turned on.
         if (m_bTorchEnabled)
         {
             // Drop the Alpha channel from the image copy to preproc frame.
-            cv::cvtColor(m_cvFrame, m_cvTorchProcFrame, cv::COLOR_BGRA2BGR);
+            cv::cvtColor(m_cvFrame, m_cvTorchProcFrame, cv::COLOR_BGRA2RGB);
             // Detect objects in the image.
             std::vector<objectdetectutils::Object> vNewTorchObjects =
                 torchobject::Detect(m_cvTorchProcFrame, *m_pTorchDetector, m_fTorchMinObjectConfidence, m_fTorchNMSThreshold);
@@ -314,7 +314,7 @@ void ObjectDetector::ThreadedContinuousCode()
         this->UpdateDetectedObjects(m_vNewlyDetectedObjects);
 
         // Draw object overlays onto normal image.
-        torchobject::DrawDetections(m_cvTorchProcFrame, m_vDetectedObjects);
+        torchobject::DrawDetections(m_cvTorchOverlayFrame, m_vDetectedObjects);
         /////////////////////////////////////////////////////////////////////////////////////
     }
 

--- a/src/vision/objects/ObjectDetector.h
+++ b/src/vision/objects/ObjectDetector.h
@@ -118,7 +118,6 @@ class ObjectDetector : public AutonomyThread<void>
         cv::Mat m_cvFrame;
         cv::cuda::GpuMat m_cvGPUFrame;
         cv::Mat m_cvTorchProcFrame;
-        cv::Mat m_cvTorchOverlayFrame;
         cv::Mat m_cvPointCloud;
         cv::cuda::GpuMat m_cvGPUPointCloud;
 

--- a/src/vision/objects/ObjectDetector.h
+++ b/src/vision/objects/ObjectDetector.h
@@ -118,6 +118,7 @@ class ObjectDetector : public AutonomyThread<void>
         cv::Mat m_cvFrame;
         cv::cuda::GpuMat m_cvGPUFrame;
         cv::Mat m_cvTorchProcFrame;
+        cv::Mat m_cvTorchOverlayFrame;
         cv::Mat m_cvPointCloud;
         cv::cuda::GpuMat m_cvGPUPointCloud;
 


### PR DESCRIPTION
### **Description**

Weekend test‐driven tweaks to rover autonomy: updated drive limits, cleaned up RoveComm telemetry, tightened clamp logic, and streamlined detection code.

### **Key Changes**

* **RoveComm**: Bumped manifest IDs/counts in submodule.
* **Drive Limits**: `DRIVE_MAX_EFFORT` ↑ 0.4 → 0.5 (and min → –0.5); motor powers now scale off this.
* **Clamp Logic**: Removed `MapRange`; direct clamp to effort range in `DriveBoard`.
* **Telemetry Types**: Switched FPS vector/index in `main.cpp` from `int` → `uint32_t`.
* **Stuck Detection**: Wrapped checks behind `*_ENABLE_STUCK_DETECT` flags in all states.
* **Visualization**: Changed object‐dot color to purple; eliminated redundant color‐space conversions in detection.

### **How It Works**

Constants drive all power settings; clamping uses unified effort bounds; stuck checks only run when enabled; telemetry matches ground expectation.

### **Testing**

* **Build/Unit**: Clean compile, all tests pass.
* **Simulation**: Verified drive response, stuck‐detect toggles, and correct RoveComm packets.
* **Manual**: Confirmed object plotting and telemetry integrity on ground station.
* **Colorspace Verification**: Still need to more thoroughly test the color channel differences between the sim and ZED camera. Currently, the SIM feed looks normal.
