### PR TITLE
Add Sensors Data Retrieval to ZEDCam Class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS 1 CACHE INTERNAL "Suppress developer warni
 ####################################################################################################################
 
 ## Enable or Disable Simulation Mode
-option(BUILD_SIM_MODE "Enable Simulation Mode" OFF)
+option(BUILD_SIM_MODE "Enable Simulation Mode" ON)
 
 ## Enable or Disable Code Coverage Mode
 option(BUILD_CODE_COVERAGE "Enable Code Coverage Mode" OFF)

--- a/examples/vision/cameras/OpenZEDCam.hpp
+++ b/examples/vision/cameras/OpenZEDCam.hpp
@@ -75,6 +75,7 @@ void RunExample()
     cv::cuda::GpuMat cvGPUPointCloud1;
     // Declare other data types to store data in.
     ZEDCam::Pose stPose;
+    sl::SensorsData slSensors;
 
     // Declare FPS counter.
     IPS FPS = IPS();
@@ -103,7 +104,8 @@ void RunExample()
             fuPointCloudCopyStatus = ExampleZEDCam1->RequestPointCloudCopy(cvPointCloud1);
         }
         // Grab other info from camera.
-        std::future<bool> fuPoseCopyStatus = ExampleZEDCam1->RequestPositionalPoseCopy(stPose);
+        // std::future<bool> fuPoseCopyStatus    = ExampleZEDCam1->RequestPositionalPoseCopy(stPose);
+        std::future<bool> fuSensorsCopyStatus = ExampleZEDCam1->RequestSensorsCopy(slSensors);
 
         // Wait for the frames to be copied.
         if (fuFrameCopyStatus.get() && fuDepthCopyStatus.get() && fuPointCloudCopyStatus.get())
@@ -131,19 +133,42 @@ void RunExample()
             // Split color from point cloud.
             imgops::SplitPointCloudColors(cvPointCloud1, cvPointCloudColor1);
 
-            // Wait for the other info to be copied.
-            if (fuPoseCopyStatus.get())
+            // // Wait for the other info to be copied.
+            // if (fuPoseCopyStatus.get())
+            // {
+            //     LOG_INFO(logging::g_qConsoleLogger,
+            //              "Positional Tracking: X: {} | Y: {} | Z: {}",
+            //              stPose.stTranslation.dX,
+            //              stPose.stTranslation.dY,
+            //              stPose.stTranslation.dZ);
+            //     LOG_INFO(logging::g_qConsoleLogger,
+            //              "Positional Orientation: Roll: {} | Pitch: {} | Yaw:{}",
+            //              stPose.stEulerAngles.dXO,
+            //              stPose.stEulerAngles.dYO,
+            //              stPose.stEulerAngles.dZO);
+            // }
+
+            // Wait for sensors data to be copied.
+            if (fuSensorsCopyStatus.get())
             {
+                // Unpack sensors data.
+                double dRelativeAltitude = slSensors.barometer.relative_altitude;
+                float fTemperature       = 0.0;
+                slSensors.temperature.get(sl::SensorsData::TemperatureData::SENSOR_LOCATION::IMU, fTemperature);
+                float fMagHeading    = slSensors.magnetometer.magnetic_heading;
+                sl::float3 slIMUPose = slSensors.imu.pose.getEulerAngles(false);
+                float fIMUPoseX      = slIMUPose.x;
+                float fIMUPoseY      = slIMUPose.y;
+                float fIMUPoseZ      = slIMUPose.z;
+
                 LOG_INFO(logging::g_qConsoleLogger,
-                         "Positional Tracking: X: {} | Y: {} | Z: {}",
-                         stPose.stTranslation.dX,
-                         stPose.stTranslation.dY,
-                         stPose.stTranslation.dZ);
-                LOG_INFO(logging::g_qConsoleLogger,
-                         "Positional Orientation: Roll: {} | Pitch: {} | Yaw:{}",
-                         stPose.stEulerAngles.dXO,
-                         stPose.stEulerAngles.dYO,
-                         stPose.stEulerAngles.dZO);
+                         "Sensors Data: Altitude: {} | Temperature: {} | Mag Heading: {} | IMU PoseX: {} | IMU PoseY: {} | IMU PoseZ: {}",
+                         dRelativeAltitude,
+                         fTemperature,
+                         fMagHeading,
+                         fIMUPoseX,
+                         fIMUPoseY,
+                         fIMUPoseZ);
             }
 
             // Print info.
@@ -155,9 +180,9 @@ void RunExample()
             }
 
             // Display frames.
-            cv::imshow("FRAME1", cvNormalFrame1);
-            cv::imshow("DEPTH1", cvDepthFrame1);
-            cv::imshow("POINT CLOUD COLOR 1", cvPointCloudColor1);
+            // cv::imshow("FRAME1", cvNormalFrame1);
+            // cv::imshow("DEPTH1", cvDepthFrame1);
+            // cv::imshow("POINT CLOUD COLOR 1", cvPointCloudColor1);
         }
 
         // Tick FPS counter.
@@ -165,9 +190,9 @@ void RunExample()
         // Print FPS of main loop.
         LOG_INFO(logging::g_qConsoleLogger, "Main FPS: {}", FPS.GetAverageIPS());
 
-        char chKey = cv::waitKey(1);
-        if (chKey == 27)    // Press 'Esc' key to exit
-            break;
+        // char chKey = cv::waitKey(1);
+        // if (chKey == 27)    // Press 'Esc' key to exit
+        //     break;
     }
 
     // Close all OpenCV windows.

--- a/examples/vision/cameras/OpenZEDCam.hpp
+++ b/examples/vision/cameras/OpenZEDCam.hpp
@@ -104,7 +104,7 @@ void RunExample()
             fuPointCloudCopyStatus = ExampleZEDCam1->RequestPointCloudCopy(cvPointCloud1);
         }
         // Grab other info from camera.
-        // std::future<bool> fuPoseCopyStatus    = ExampleZEDCam1->RequestPositionalPoseCopy(stPose);
+        std::future<bool> fuPoseCopyStatus    = ExampleZEDCam1->RequestPositionalPoseCopy(stPose);
         std::future<bool> fuSensorsCopyStatus = ExampleZEDCam1->RequestSensorsCopy(slSensors);
 
         // Wait for the frames to be copied.
@@ -133,20 +133,20 @@ void RunExample()
             // Split color from point cloud.
             imgops::SplitPointCloudColors(cvPointCloud1, cvPointCloudColor1);
 
-            // // Wait for the other info to be copied.
-            // if (fuPoseCopyStatus.get())
-            // {
-            //     LOG_INFO(logging::g_qConsoleLogger,
-            //              "Positional Tracking: X: {} | Y: {} | Z: {}",
-            //              stPose.stTranslation.dX,
-            //              stPose.stTranslation.dY,
-            //              stPose.stTranslation.dZ);
-            //     LOG_INFO(logging::g_qConsoleLogger,
-            //              "Positional Orientation: Roll: {} | Pitch: {} | Yaw:{}",
-            //              stPose.stEulerAngles.dXO,
-            //              stPose.stEulerAngles.dYO,
-            //              stPose.stEulerAngles.dZO);
-            // }
+            // Wait for the other info to be copied.
+            if (fuPoseCopyStatus.get())
+            {
+                LOG_INFO(logging::g_qConsoleLogger,
+                         "Positional Tracking: X: {} | Y: {} | Z: {}",
+                         stPose.stTranslation.dX,
+                         stPose.stTranslation.dY,
+                         stPose.stTranslation.dZ);
+                LOG_INFO(logging::g_qConsoleLogger,
+                         "Positional Orientation: Roll: {} | Pitch: {} | Yaw:{}",
+                         stPose.stEulerAngles.dXO,
+                         stPose.stEulerAngles.dYO,
+                         stPose.stEulerAngles.dZO);
+            }
 
             // Wait for sensors data to be copied.
             if (fuSensorsCopyStatus.get())
@@ -180,9 +180,9 @@ void RunExample()
             }
 
             // Display frames.
-            // cv::imshow("FRAME1", cvNormalFrame1);
-            // cv::imshow("DEPTH1", cvDepthFrame1);
-            // cv::imshow("POINT CLOUD COLOR 1", cvPointCloudColor1);
+            cv::imshow("FRAME1", cvNormalFrame1);
+            cv::imshow("DEPTH1", cvDepthFrame1);
+            cv::imshow("POINT CLOUD COLOR 1", cvPointCloudColor1);
         }
 
         // Tick FPS counter.
@@ -190,9 +190,9 @@ void RunExample()
         // Print FPS of main loop.
         LOG_INFO(logging::g_qConsoleLogger, "Main FPS: {}", FPS.GetAverageIPS());
 
-        // char chKey = cv::waitKey(1);
-        // if (chKey == 27)    // Press 'Esc' key to exit
-        //     break;
+        char chKey = cv::waitKey(1);
+        if (chKey == 27)    // Press 'Esc' key to exit
+            break;
     }
 
     // Close all OpenCV windows.

--- a/src/interfaces/ZEDCamera.hpp
+++ b/src/interfaces/ZEDCamera.hpp
@@ -300,6 +300,124 @@ class ZEDCamera : public Camera<cv::Mat>
         }
 
         /******************************************************************************
+         * @brief Puts a Pose pointer into a queue so a copy of a Pose from the camera can be written to it.
+         *
+         * @param stPose - A reference to the Pose to store the Pose in.
+         * @return std::future<bool> - A future that should be waited on before the passed in Pose is used.
+         *
+         * @author clayjay3 (claytonraycowen@gmail.com)
+         * @date 2024-12-25
+         ******************************************************************************/
+        virtual std::future<bool> RequestPositionalPoseCopy(Pose& stPose) = 0;
+
+        /******************************************************************************
+         * @brief Puts a GeoPose pointer into a queue so a copy of a GeoPose from the camera can be written to it.
+         *
+         * @param slGeoPose - A reference to the sl::GeoPose to store the GeoPose in.
+         * @return std::future<bool> - A future that should be waited on before the passed in GeoPose is used.
+         *
+         * @author clayjay3 (claytonraycowen@gmail.com)
+         * @date 2024-12-25
+         ******************************************************************************/
+        virtual std::future<bool> RequestFusionGeoPoseCopy(sl::GeoPose& slGeoPose) = 0;
+
+        /******************************************************************************
+         * @brief Puts a FloorPlane pointer into a queue so a copy of a FloorPlane from the camera can be written to it.
+         *
+         * @param slFloorPlane - A reference to the sl::Plane to store the FloorPlane in.
+         * @return std::future<bool> - A future that should be waited on before the passed in FloorPlane is used.
+         *
+         * @author clayjay3 (claytonraycowen@gmail.com)
+         * @date 2024-12-25
+         ******************************************************************************/
+        virtual std::future<bool> RequestFloorPlaneCopy(sl::Plane& slFloorPlane)
+        {
+            // Initialize instance variables.
+            (void) slFloorPlane;
+            std::promise<bool> pmPromise;
+
+            // Immediately set the promise to false.
+            pmPromise.set_value(false);
+
+            // Submit logger message.
+            LOG_ERROR(logging::g_qSharedLogger, "ZEDCamera::RequestFloorPlaneCopy(sl::Plane& slFloorPlane) not implemented.");
+
+            return pmPromise.get_future();
+        }
+
+        /******************************************************************************
+         * @brief Puts a SensorsData pointer into a queue so a copy of a SensorsData from the camera can be written to it.
+         *
+         * @param slSensorsData - A reference to the sl::SensorsData to store the SensorsData in.
+         * @return std::future<bool> - A future that should be waited on before the passed in SensorsData is used.
+         *
+         * @author clayjay3 (claytonraycowen@gmail.com)
+         * @date 2025-08-26
+         ******************************************************************************/
+        virtual std::future<bool> RequestSensorsCopy(sl::SensorsData& slSensorsData)
+        {
+            // Initialize instance variables.
+            (void) slSensorsData;
+            std::promise<bool> pmPromise;
+
+            // Immediately set the promise to false.
+            pmPromise.set_value(false);
+
+            // Submit logger message.
+            LOG_ERROR(logging::g_qSharedLogger, "ZEDCamera::RequestSensorsCopy(sl::SensorsData& slSensorsData) not implemented.");
+
+            return pmPromise.get_future();
+        }
+
+        /******************************************************************************
+         * @brief Puts a vector of ObjectData pointers into a queue so a copy of a vector of ObjectData from the camera can be written to it.
+         *
+         * @param vObjectData - A reference to the vector of sl::ObjectData to store the ObjectData in.
+         * @return std::future<bool> - A future that should be waited on before the passed in ObjectData is used.
+         *
+         * @author clayjay3 (claytonraycowen@gmail.com)
+         * @date 2024-12-25
+         ******************************************************************************/
+        virtual std::future<bool> RequestObjectsCopy(std::vector<sl::ObjectData>& vObjectData)
+        {
+            // Initialize instance variables.
+            (void) vObjectData;
+            std::promise<bool> pmPromise;
+
+            // Immediately set the promise to false.
+            pmPromise.set_value(false);
+
+            // Submit logger message.
+            LOG_ERROR(logging::g_qSharedLogger, "ZEDCamera::RequestObjectsCopy(std::vector<sl::ObjectData>& vObjectData) not implemented.");
+
+            return pmPromise.get_future();
+        }
+
+        /******************************************************************************
+         * @brief Puts a vector of ObjectsBatch pointers into a queue so a copy of a vector of ObjectsBatch from the camera can be written to it.
+         *
+         * @param vBatchedObjectData - A reference to the vector of sl::ObjectsBatch to store the ObjectsBatch in.
+         * @return std::future<bool> - A future that should be waited on before the passed in ObjectsBatch is used.
+         *
+         * @author clayjay3 (claytonraycowen@gmail.com)
+         * @date 2024-12-25
+         ******************************************************************************/
+        virtual std::future<bool> RequestBatchedObjectsCopy(std::vector<sl::ObjectsBatch>& vBatchedObjectData)
+        {
+            // Initialize instance variables.
+            (void) vBatchedObjectData;
+            std::promise<bool> pmPromise;
+
+            // Immediately set the promise to false.
+            pmPromise.set_value(false);
+
+            // Submit logger message.
+            LOG_ERROR(logging::g_qSharedLogger, "ZEDCamera::RequestBatchedObjectsCopy(std::vector<sl::ObjectsBatch>& vBatchedObjectData) not implemented.");
+
+            return pmPromise.get_future();
+        }
+
+        /******************************************************************************
          * @brief Resets the positional tracking of the camera.
          *
          * @return sl::ERROR_CODE - The error code returned by the ZED SDK.
@@ -528,52 +646,6 @@ class ZEDCamera : public Camera<cv::Mat>
         virtual unsigned int GetCameraSerial() { return m_unCameraSerialNumber; };
 
         /******************************************************************************
-         * @brief Puts a Pose pointer into a queue so a copy of a Pose from the camera can be written to it.
-         *
-         * @param stPose - A reference to the Pose to store the Pose in.
-         * @return std::future<bool> - A future that should be waited on before the passed in Pose is used.
-         *
-         * @author clayjay3 (claytonraycowen@gmail.com)
-         * @date 2024-12-25
-         ******************************************************************************/
-        virtual std::future<bool> RequestPositionalPoseCopy(Pose& stPose) = 0;
-
-        /******************************************************************************
-         * @brief Puts a GeoPose pointer into a queue so a copy of a GeoPose from the camera can be written to it.
-         *
-         * @param slGeoPose - A reference to the sl::GeoPose to store the GeoPose in.
-         * @return std::future<bool> - A future that should be waited on before the passed in GeoPose is used.
-         *
-         * @author clayjay3 (claytonraycowen@gmail.com)
-         * @date 2024-12-25
-         ******************************************************************************/
-        virtual std::future<bool> RequestFusionGeoPoseCopy(sl::GeoPose& slGeoPose) = 0;
-
-        /******************************************************************************
-         * @brief Puts a FloorPlane pointer into a queue so a copy of a FloorPlane from the camera can be written to it.
-         *
-         * @param slFloorPlane - A reference to the sl::Plane to store the FloorPlane in.
-         * @return std::future<bool> - A future that should be waited on before the passed in FloorPlane is used.
-         *
-         * @author clayjay3 (claytonraycowen@gmail.com)
-         * @date 2024-12-25
-         ******************************************************************************/
-        virtual std::future<bool> RequestFloorPlaneCopy(sl::Plane& slFloorPlane)
-        {
-            // Initialize instance variables.
-            (void) slFloorPlane;
-            std::promise<bool> pmPromise;
-
-            // Immediately set the promise to false.
-            pmPromise.set_value(false);
-
-            // Submit logger message.
-            LOG_ERROR(logging::g_qSharedLogger, "ZEDCamera::RequestFloorPlaneCopy(sl::Plane& slFloorPlane) not implemented.");
-
-            return pmPromise.get_future();
-        }
-
-        /******************************************************************************
          * @brief Accessor for the Positional Tracking Enabled private member.
          *
          * @return true - Positional tracking is enabled.
@@ -662,54 +734,6 @@ class ZEDCamera : public Camera<cv::Mat>
          * @date 2024-12-25
          ******************************************************************************/
         virtual bool GetObjectDetectionEnabled() { return false; }
-
-        /******************************************************************************
-         * @brief Puts a vector of ObjectData pointers into a queue so a copy of a vector of ObjectData from the camera can be written to it.
-         *
-         * @param vObjectData - A reference to the vector of sl::ObjectData to store the ObjectData in.
-         * @return std::future<bool> - A future that should be waited on before the passed in ObjectData is used.
-         *
-         * @author clayjay3 (claytonraycowen@gmail.com)
-         * @date 2024-12-25
-         ******************************************************************************/
-        virtual std::future<bool> RequestObjectsCopy(std::vector<sl::ObjectData>& vObjectData)
-        {
-            // Initialize instance variables.
-            (void) vObjectData;
-            std::promise<bool> pmPromise;
-
-            // Immediately set the promise to false.
-            pmPromise.set_value(false);
-
-            // Submit logger message.
-            LOG_ERROR(logging::g_qSharedLogger, "ZEDCamera::RequestObjectsCopy(std::vector<sl::ObjectData>& vObjectData) not implemented.");
-
-            return pmPromise.get_future();
-        }
-
-        /******************************************************************************
-         * @brief Puts a vector of ObjectsBatch pointers into a queue so a copy of a vector of ObjectsBatch from the camera can be written to it.
-         *
-         * @param vBatchedObjectData - A reference to the vector of sl::ObjectsBatch to store the ObjectsBatch in.
-         * @return std::future<bool> - A future that should be waited on before the passed in ObjectsBatch is used.
-         *
-         * @author clayjay3 (claytonraycowen@gmail.com)
-         * @date 2024-12-25
-         ******************************************************************************/
-        virtual std::future<bool> RequestBatchedObjectsCopy(std::vector<sl::ObjectsBatch>& vBatchedObjectData)
-        {
-            // Initialize instance variables.
-            (void) vBatchedObjectData;
-            std::promise<bool> pmPromise;
-
-            // Immediately set the promise to false.
-            pmPromise.set_value(false);
-
-            // Submit logger message.
-            LOG_ERROR(logging::g_qSharedLogger, "ZEDCamera::RequestBatchedObjectsCopy(std::vector<sl::ObjectsBatch>& vBatchedObjectData) not implemented.");
-
-            return pmPromise.get_future();
-        }
 
     protected:
         /////////////////////////////////////////

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
  * @copyright Copyright Mars Rover Design Team 2023 - All Rights Reserved
  ******************************************************************************/
 
+#include "../examples/vision/cameras/OpenZEDCam.hpp"
 #include "./AutonomyGlobals.h"
 #include "./AutonomyLogging.h"
 #include "./AutonomyNetworking.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,6 @@
  * @copyright Copyright Mars Rover Design Team 2023 - All Rights Reserved
  ******************************************************************************/
 
-#include "../examples/vision/cameras/OpenZEDCam.hpp"
 #include "./AutonomyGlobals.h"
 #include "./AutonomyLogging.h"
 #include "./AutonomyNetworking.h"

--- a/src/vision/cameras/ZEDCam.cpp
+++ b/src/vision/cameras/ZEDCam.cpp
@@ -568,6 +568,24 @@ void ZEDCam::ThreadedContinuousCode()
                 }
             }
 
+            // Get the IMU, barometer, magnetometer, and temperature sensor info from the camera.
+            if (m_bSensorsQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
+            {
+                // Get the sensor data from the camera.
+                slReturnCode = m_slCamera.getSensorsData(m_slSensorsData, sl::TIME_REFERENCE::CURRENT);
+
+                // Check if the sensor data was retrieved successfully.
+                if (slReturnCode != sl::ERROR_CODE::SUCCESS)
+                {
+                    // Submit logger message.
+                    LOG_WARNING(logging::g_qSharedLogger,
+                                "Unable to retrieve sensor data for stereo camera {} ({})! sl::ERROR_CODE is: {}",
+                                sl::toString(m_slCameraModel).get(),
+                                m_unCameraSerialNumber,
+                                sl::toString(slReturnCode).get());
+                }
+            }
+
             // Check if object detection is enabled.
             if (m_slCamera.isObjectDetectionEnabled())
             {
@@ -637,11 +655,12 @@ void ZEDCam::ThreadedContinuousCode()
     std::shared_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
     // Check if any requests have been made.
     if (!m_qFrameCopySchedule.empty() || !m_qGPUFrameCopySchedule.empty() || !m_qCustomBoxIngestSchedule.empty() || !m_qPoseCopySchedule.empty() ||
-        !m_qGeoPoseCopySchedule.empty() || m_qFloorCopySchedule.size() || !m_qObjectDataCopySchedule.empty() || !m_qObjectBatchedDataCopySchedule.empty())
+        !m_qGeoPoseCopySchedule.empty() || !m_qFloorCopySchedule.empty() || !m_qSensorsCopySchedule.empty() || !m_qObjectDataCopySchedule.empty() ||
+        !m_qObjectBatchedDataCopySchedule.empty())
     {
         // Add the length of all queues together to determine how many tasks need to be run.
         size_t siTotalQueueLength = m_qFrameCopySchedule.size() + m_qGPUFrameCopySchedule.size() + m_qCustomBoxIngestSchedule.size() + m_qPoseCopySchedule.size() +
-                                    m_qGeoPoseCopySchedule.size() + m_qFloorCopySchedule.size() + m_qObjectDataCopySchedule.size() +
+                                    m_qGeoPoseCopySchedule.size() + m_qFloorCopySchedule.size() + m_qSensorsCopySchedule.size() + m_qObjectDataCopySchedule.size() +
                                     m_qObjectBatchedDataCopySchedule.size();
 
         // Start the thread pool to copy member variables to requesting other threads. Num of tasks queued depends on number of member variables updates and requests.
@@ -661,6 +680,7 @@ void ZEDCam::ThreadedContinuousCode()
             m_bPosesQueued.store(false, ATOMIC_MEMORY_ORDER_METHOD);
             m_bGeoPosesQueued.store(false, ATOMIC_MEMORY_ORDER_METHOD);
             m_bFloorsQueued.store(false, ATOMIC_MEMORY_ORDER_METHOD);
+            m_bSensorsQueued.store(false, ATOMIC_MEMORY_ORDER_METHOD);
             m_bObjectsQueued.store(false, ATOMIC_MEMORY_ORDER_METHOD);
             m_bBatchedObjectsQueued.store(false, ATOMIC_MEMORY_ORDER_METHOD);
 
@@ -876,11 +896,41 @@ void ZEDCam::PooledLinearCode()
 
         // Copy pose.
         *stContainer.pData = sl::Plane(m_slFloorPlane);
+
+        // Signal future that the data has been successfully retrieved.
+        stContainer.pCopiedDataStatus->set_value(true);
     }
     else
     {
         // Release lock.
         lkPlaneQueue.unlock();
+    }
+
+    /////////////////////////////
+    //  Sensors queue.
+    /////////////////////////////
+    // Acquire mutex for getting frames out of the sensors queue.
+    std::unique_lock<std::shared_mutex> lkSensorsQueue(m_muSensorsCopyMutex);
+    // Check if the queue is empty.
+    if (!m_qSensorsCopySchedule.empty())
+    {
+        // Get frame container out of queue.
+        containers::DataFetchContainer<sl::SensorsData> stContainer = m_qSensorsCopySchedule.front();
+        // Pop out of queue.
+        m_qSensorsCopySchedule.pop();
+        // Release lock.
+        lkSensorsQueue.unlock();
+
+        // Copy pose.
+        *stContainer.pData = sl::SensorsData(m_slSensorsData);
+
+        // Signal future that the data had been successfully retrieved.
+        stContainer.pCopiedDataStatus->set_value(true);
+    }
+    else
+    {
+        // Release lock.
+        lkSensorsQueue.unlock();
     }
 
     /////////////////////////////
@@ -1178,6 +1228,344 @@ std::future<bool> ZEDCam::RequestPointCloudCopy(cv::cuda::GpuMat& cvGPUPointClou
 
     // Return the future from the promise stored in the container.
     return stContainer.pCopiedFrameStatus->get_future();
+}
+
+/******************************************************************************
+ * @brief Requests the current pose of the camera relative to it's start pose or the origin of the set pose.
+ *      Puts a Pose pointer into a queue so a copy of a pose from the camera can be written to it.
+ *      If positional tracking is not enabled, this method will return false and the ZEDCam::Pose may be uninitialized.
+ *
+ * @param stPose - A reference to the ZEDCam::Pose object to copy the current camera pose to.
+ * @return std::future<bool> - A future that should be waited on before the passed in sl::Pose is used.
+ *                          Value will be true if pose was successfully retrieved.
+ *
+ * @note If this camera is acting as the ZEDSDK Fusion master instance, then the positional pose returned will be from
+ *      the Fusion instance. aka The Fused GNSS and visual inertial odometry will be returned.
+ *
+ * @author clayjay3 (claytonraycowen@gmail.com)
+ * @date 2023-08-27
+ ******************************************************************************/
+std::future<bool> ZEDCam::RequestPositionalPoseCopy(Pose& stPose)
+{
+    // Acquire read lock.
+    std::shared_lock<std::shared_mutex> lkCameraLock(m_muCameraMutex);
+    // Check if positional tracking has been enabled.
+    if (m_slCamera.isPositionalTrackingEnabled())
+    {
+        // Release lock.
+        lkCameraLock.unlock();
+        // Assemble the data container.
+        containers::DataFetchContainer<Pose> stContainer(stPose);
+
+        // Acquire lock on pose copy queue.
+        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
+        // Append pose fetch container to the schedule queue.
+        m_qPoseCopySchedule.push(stContainer);
+        // Release lock on the pose schedule queue.
+        lkSchedulers.unlock();
+
+        // Check if pose queue toggle has already been set.
+        if (!m_bPosesQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
+        {
+            // Signify that the pose queue is not empty.
+            m_bPosesQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
+        }
+
+        // Return the future from the promise stored in the container.
+        return stContainer.pCopiedDataStatus->get_future();
+    }
+    else
+    {
+        // Release lock.
+        lkCameraLock.unlock();
+        // Submit logger message.
+        LOG_WARNING(logging::g_qSharedLogger, "Attempted to get ZED positional pose but positional tracking is not enabled or is still initializing!");
+
+        // Create dummy promise to return the future.
+        std::promise<bool> pmDummyPromise;
+        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
+        // Set future value.
+        pmDummyPromise.set_value(false);
+
+        // Return unsuccessful.
+        return fuDummyFuture;
+    }
+}
+
+/******************************************************************************
+ * @brief Requests the current geo pose of the camera. This method should be used to retrieve ONLY the GNSS data from
+ *      the ZEDSDK's Fusion module. Puts a GeoPose pointer into a queue so a copy of a GeoPose from the
+ *      camera can be written to it. If positional tracking or fusion is disabled for this camera, then this method will return false
+ *      and the sl::GeoPose may be uninitialized.
+ *
+ * @param slGeoPose - A reference to the sl::GeoPose object to copy the current geo pose to.
+ * @return std::future<bool> - A future that should be waited on before the passed in sl::GeoPose is used.
+ *                          Value will be true if geo pose was successfully retrieved.
+ *
+ * @note This camera must be a Fusion Master and the NavBoard must be giving accurate info to the camera for this to be functional.
+ *
+ * @author clayjay3 (claytonraycowen@gmail.com)
+ * @date 2024-01-25
+ ******************************************************************************/
+std::future<bool> ZEDCam::RequestFusionGeoPoseCopy(sl::GeoPose& slGeoPose)
+{
+    // Acquire read lock.
+    std::shared_lock<std::shared_mutex> lkCameraLock(m_muCameraMutex);
+    // Check if positional tracking has been enabled.
+    if (m_bCameraIsFusionMaster && m_slCamera.isPositionalTrackingEnabled())
+    {
+        // Release lock.
+        lkCameraLock.unlock();
+        // Assemble the data container.
+        containers::DataFetchContainer<sl::GeoPose> stContainer(slGeoPose);
+
+        // Acquire lock on frame copy queue.
+        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
+        // Append frame fetch container to the schedule queue.
+        m_qGeoPoseCopySchedule.push(stContainer);
+        // Release lock on the frame schedule queue.
+        lkSchedulers.unlock();
+
+        // Check if pose queue toggle has already been set.
+        if (!m_bGeoPosesQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
+        {
+            // Signify that the pose queue is not empty.
+            m_bGeoPosesQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
+        }
+
+        // Return the future from the promise stored in the container.
+        return stContainer.pCopiedDataStatus->get_future();
+    }
+    else
+    {
+        // Release lock.
+        lkCameraLock.unlock();
+        // Submit logger message.
+        LOG_WARNING(logging::g_qSharedLogger,
+                    "Attempted to get ZED FUSION geo pose but positional tracking is not enabled and/or this camera was not initialized as a Fusion Master!");
+
+        // Create dummy promise to return the future.
+        std::promise<bool> pmDummyPromise;
+        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
+        // Set future value.
+        pmDummyPromise.set_value(false);
+
+        // Return unsuccessful.
+        return fuDummyFuture;
+    }
+}
+
+/******************************************************************************
+ * @brief Requests the current floor plane of the camera relative to it's current pose.
+ *      Puts a Plane pointer into a queue so a copy of the floor plane from the camera can be written to it.
+ *      If positional tracking is not enabled, this method will return false and the sl::Plane may be uninitialized.
+ *
+ * @param slPlane - A reference to the sl::Plane object to copy the current camera floor plane to.
+ * @return std::future<bool> - A future that should be waited on before the passed in sl::Plane is used.
+ *                          Value will be true if data was successfully retrieved.
+ *
+ * @author clayjay3 (claytonraycowen@gmail.com)
+ * @date 2023-10-22
+ ******************************************************************************/
+std::future<bool> ZEDCam::RequestFloorPlaneCopy(sl::Plane& slPlane)
+{
+    // Acquire read lock.
+    std::shared_lock<std::shared_mutex> lkCameraLock(m_muCameraMutex);
+    // Check if positional tracking has been enabled.
+    if (m_slCamera.isPositionalTrackingEnabled())
+    {
+        // Release lock.
+        lkCameraLock.unlock();
+        // Assemble the data container.
+        containers::DataFetchContainer<sl::Plane> stContainer(slPlane);
+
+        // Acquire lock on pose copy queue.
+        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
+        // Append data fetch container to the schedule queue.
+        m_qFloorCopySchedule.push(stContainer);
+        // Release lock on the pose schedule queue.
+        lkSchedulers.unlock();
+
+        // Check if pose queue toggle has already been set.
+        if (!m_bFloorsQueued.load(std::memory_order_relaxed))
+        {
+            // Signify that the pose queue is not empty.
+            m_bFloorsQueued.store(true, std::memory_order_relaxed);
+        }
+
+        // Return the future from the promise stored in the container.
+        return stContainer.pCopiedDataStatus->get_future();
+    }
+    else
+    {
+        // Release lock.
+        lkCameraLock.unlock();
+        // Submit logger message.
+        LOG_WARNING(logging::g_qSharedLogger, "Attempted to get ZED floor plane but positional tracking is not enabled!");
+
+        // Create dummy promise to return the future.
+        std::promise<bool> pmDummyPromise;
+        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
+        // Set future value.
+        pmDummyPromise.set_value(false);
+
+        // Return unsuccessful.
+        return fuDummyFuture;
+    }
+}
+
+/******************************************************************************
+ * @brief Requests the most up to date sensors data from the camera. This data
+ *  include IMU pose and raw values, barometer, magnetometer, and temperature data.
+ *
+ * @param slSensorsData - A reference to the sl::SensorsData struct to copy data into.
+ * @return std::future<bool> - A future that should be waited on before the passed in sl::SensorsData is used.
+ *                          Value will be true if data was successfully retrieved.
+ *
+ * @author clayjay3 (claytonraycowen@gmail.com)
+ * @date 2025-08-26
+ ******************************************************************************/
+std::future<bool> ZEDCam::RequestSensorsCopy(sl::SensorsData& slSensorsData)
+{
+    // Assemble the data container.
+    containers::DataFetchContainer<sl::SensorsData> stContainer(slSensorsData);
+
+    // Acquire lock on sensors copy queue.
+    std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
+    // Append sensors fetch container to the schedule queue.
+    m_qSensorsCopySchedule.push(stContainer);
+    // Release lock on the sensors schedule queue.
+    lkSchedulers.unlock();
+
+    // Check if sensors queue toggle has already been set.
+    if (!m_bSensorsQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
+    {
+        // Signify that the sensors queue is not empty.
+        m_bSensorsQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
+    }
+
+    // Return the future from the promise stored in the container.
+    return stContainer.pCopiedDataStatus->get_future();
+}
+
+/******************************************************************************
+ * @brief Requests a current copy of the tracked objects from the camera.
+ *      Puts a pointer to a vector containing sl::ObjectData into a queue so a copy of a frame from the camera can be written to it.
+ *
+ * @param vObjectData - A vector that will have data copied to it containing sl::ObjectData objects.
+ * @return std::future<bool> - A future that should be waited on before the passed in vector is used.
+ *                          Value will be true if data was successfully retrieved.
+ *
+ * @author clayjay3 (claytonraycowen@gmail.com)
+ * @date 2023-08-27
+ ******************************************************************************/
+std::future<bool> ZEDCam::RequestObjectsCopy(std::vector<sl::ObjectData>& vObjectData)
+{
+    // Acquire read lock.
+    std::shared_lock<std::shared_mutex> lkCameraLock(m_muCameraMutex);
+    // Check if object detection has been enabled.
+    if (m_slCamera.isObjectDetectionEnabled())
+    {
+        // Release lock.
+        lkCameraLock.unlock();
+        // Assemble the data container.
+        containers::DataFetchContainer<std::vector<sl::ObjectData>> stContainer(vObjectData);
+
+        // Acquire lock on object copy queue.
+        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
+        // Append data fetch container to the schedule queue.
+        m_qObjectDataCopySchedule.push(stContainer);
+        // Release lock on the object schedule queue.
+        lkSchedulers.unlock();
+
+        // Check if objects queue toggle has already been set.
+        if (!m_bObjectsQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
+        {
+            // Signify that the objects queue is not empty.
+            m_bObjectsQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
+        }
+
+        // Return the future from the promise stored in the container.
+        return stContainer.pCopiedDataStatus->get_future();
+    }
+    else
+    {
+        // Release lock.
+        lkCameraLock.unlock();
+        // Submit logger message.
+        LOG_WARNING(logging::g_qSharedLogger, "Attempted to get ZED object data but object detection/tracking is not enabled!");
+
+        // Create dummy promise to return the future.
+        std::promise<bool> pmDummyPromise;
+        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
+        // Set future value.
+        pmDummyPromise.set_value(false);
+
+        // Return unsuccessful.
+        return fuDummyFuture;
+    }
+}
+
+/******************************************************************************
+ * @brief If batching is enabled, this requests the normal objects and passes them to
+ *  the the internal batching queue of the zed api. This performs short-term re-identification
+ *  with deep learning and trajectories filtering. Batching must have been set to enabled when
+ *  EnableObjectDetection() was called. Most of the time the vector will be empty and will be
+ *  filled every ZED_OBJDETECTION_BATCH_LATENCY.
+ *
+ * @param vBatchedObjectData - A vector containing objects of sl::ObjectsBatch object that will
+ *                              have object data copied to.
+ * @return std::future<bool> - A future that should be waited on before the passed in vector is used.
+ *                          Value will be true if data was successfully retrieved.
+ *
+ * @author clayjay3 (claytonraycowen@gmail.com)
+ * @date 2023-08-30
+ ******************************************************************************/
+std::future<bool> ZEDCam::RequestBatchedObjectsCopy(std::vector<sl::ObjectsBatch>& vBatchedObjectData)
+{
+    // Acquire read lock.
+    std::shared_lock<std::shared_mutex> lkCameraLock(m_muCameraMutex);
+    // Check if object detection and batching has been enabled.
+    if (m_slCamera.isObjectDetectionEnabled() && m_slObjectDetectionBatchParams.enable)
+    {
+        // Release lock.
+        lkCameraLock.unlock();
+        // Assemble the data container.
+        containers::DataFetchContainer<std::vector<sl::ObjectsBatch>> stContainer(vBatchedObjectData);
+
+        // Acquire lock on batched object copy queue.
+        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
+        // Append data fetch container to the schedule queue.
+        m_qObjectBatchedDataCopySchedule.push(stContainer);
+        // Release lock on the data schedule queue.
+        lkSchedulers.unlock();
+
+        // Check if objects queue toggle has already been set.
+        if (!m_bBatchedObjectsQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
+        {
+            // Signify that the objects queue is not empty.
+            m_bBatchedObjectsQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
+        }
+
+        // Return the future from the promise stored in the container.
+        return stContainer.pCopiedDataStatus->get_future();
+    }
+    else
+    {
+        // Release lock.
+        lkCameraLock.unlock();
+        // Submit logger message.
+        LOG_WARNING(logging::g_qSharedLogger, "Attempted to get ZED batched object data but object detection/tracking is not enabled!");
+
+        // Create dummy promise to return the future.
+        std::promise<bool> pmDummyPromise;
+        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
+        // Set future value.
+        pmDummyPromise.set_value(false);
+
+        // Return unsuccessful.
+        return fuDummyFuture;
+    }
 }
 
 /******************************************************************************
@@ -1891,190 +2279,6 @@ unsigned int ZEDCam::GetCameraSerial()
 }
 
 /******************************************************************************
- * @brief Requests the current pose of the camera relative to it's start pose or the origin of the set pose.
- *      Puts a Pose pointer into a queue so a copy of a pose from the camera can be written to it.
- *      If positional tracking is not enabled, this method will return false and the ZEDCam::Pose may be uninitialized.
- *
- * @param stPose - A reference to the ZEDCam::Pose object to copy the current camera pose to.
- * @return std::future<bool> - A future that should be waited on before the passed in sl::Pose is used.
- *                          Value will be true if pose was successfully retrieved.
- *
- * @note If this camera is acting as the ZEDSDK Fusion master instance, then the positional pose returned will be from
- *      the Fusion instance. aka The Fused GNSS and visual inertial odometry will be returned.
- *
- * @author clayjay3 (claytonraycowen@gmail.com)
- * @date 2023-08-27
- ******************************************************************************/
-std::future<bool> ZEDCam::RequestPositionalPoseCopy(Pose& stPose)
-{
-    // Acquire read lock.
-    std::shared_lock<std::shared_mutex> lkCameraLock(m_muCameraMutex);
-    // Check if positional tracking has been enabled.
-    if (m_slCamera.isPositionalTrackingEnabled())
-    {
-        // Release lock.
-        lkCameraLock.unlock();
-        // Assemble the data container.
-        containers::DataFetchContainer<Pose> stContainer(stPose);
-
-        // Acquire lock on pose copy queue.
-        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
-        // Append pose fetch container to the schedule queue.
-        m_qPoseCopySchedule.push(stContainer);
-        // Release lock on the pose schedule queue.
-        lkSchedulers.unlock();
-
-        // Check if pose queue toggle has already been set.
-        if (!m_bPosesQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
-        {
-            // Signify that the pose queue is not empty.
-            m_bPosesQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
-        }
-
-        // Return the future from the promise stored in the container.
-        return stContainer.pCopiedDataStatus->get_future();
-    }
-    else
-    {
-        // Release lock.
-        lkCameraLock.unlock();
-        // Submit logger message.
-        LOG_WARNING(logging::g_qSharedLogger, "Attempted to get ZED positional pose but positional tracking is not enabled or is still initializing!");
-
-        // Create dummy promise to return the future.
-        std::promise<bool> pmDummyPromise;
-        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
-        // Set future value.
-        pmDummyPromise.set_value(false);
-
-        // Return unsuccessful.
-        return fuDummyFuture;
-    }
-}
-
-/******************************************************************************
- * @brief Requests the current geo pose of the camera. This method should be used to retrieve ONLY the GNSS data from
- *      the ZEDSDK's Fusion module. Puts a GeoPose pointer into a queue so a copy of a GeoPose from the
- *      camera can be written to it. If positional tracking or fusion is disabled for this camera, then this method will return false
- *      and the sl::GeoPose may be uninitialized.
- *
- * @param slGeoPose - A reference to the sl::GeoPose object to copy the current geo pose to.
- * @return std::future<bool> - A future that should be waited on before the passed in sl::GeoPose is used.
- *                          Value will be true if geo pose was successfully retrieved.
- *
- * @note This camera must be a Fusion Master and the NavBoard must be giving accurate info to the camera for this to be functional.
- *
- * @author clayjay3 (claytonraycowen@gmail.com)
- * @date 2024-01-25
- ******************************************************************************/
-std::future<bool> ZEDCam::RequestFusionGeoPoseCopy(sl::GeoPose& slGeoPose)
-{
-    // Acquire read lock.
-    std::shared_lock<std::shared_mutex> lkCameraLock(m_muCameraMutex);
-    // Check if positional tracking has been enabled.
-    if (m_bCameraIsFusionMaster && m_slCamera.isPositionalTrackingEnabled())
-    {
-        // Release lock.
-        lkCameraLock.unlock();
-        // Assemble the data container.
-        containers::DataFetchContainer<sl::GeoPose> stContainer(slGeoPose);
-
-        // Acquire lock on frame copy queue.
-        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
-        // Append frame fetch container to the schedule queue.
-        m_qGeoPoseCopySchedule.push(stContainer);
-        // Release lock on the frame schedule queue.
-        lkSchedulers.unlock();
-
-        // Check if pose queue toggle has already been set.
-        if (!m_bGeoPosesQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
-        {
-            // Signify that the pose queue is not empty.
-            m_bGeoPosesQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
-        }
-
-        // Return the future from the promise stored in the container.
-        return stContainer.pCopiedDataStatus->get_future();
-    }
-    else
-    {
-        // Release lock.
-        lkCameraLock.unlock();
-        // Submit logger message.
-        LOG_WARNING(logging::g_qSharedLogger,
-                    "Attempted to get ZED FUSION geo pose but positional tracking is not enabled and/or this camera was not initialized as a Fusion Master!");
-
-        // Create dummy promise to return the future.
-        std::promise<bool> pmDummyPromise;
-        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
-        // Set future value.
-        pmDummyPromise.set_value(false);
-
-        // Return unsuccessful.
-        return fuDummyFuture;
-    }
-}
-
-/******************************************************************************
- * @brief Requests the current floor plane of the camera relative to it's current pose.
- *      Puts a Plane pointer into a queue so a copy of the floor plane from the camera can be written to it.
- *      If positional tracking is not enabled, this method will return false and the sl::Plane may be uninitialized.
- *
- * @param slPlane - A reference to the sl::Plane object to copy the current camera floor plane to.
- * @return std::future<bool> - A future that should be waited on before the passed in sl::Plane is used.
- *                          Value will be true if data was successfully retrieved.
- *
- * @author clayjay3 (claytonraycowen@gmail.com)
- * @date 2023-10-22
- ******************************************************************************/
-std::future<bool> ZEDCam::RequestFloorPlaneCopy(sl::Plane& slPlane)
-{
-    // Acquire read lock.
-    std::shared_lock<std::shared_mutex> lkCameraLock(m_muCameraMutex);
-    // Check if positional tracking has been enabled.
-    if (m_slCamera.isPositionalTrackingEnabled())
-    {
-        // Release lock.
-        lkCameraLock.unlock();
-        // Assemble the data container.
-        containers::DataFetchContainer<sl::Plane> stContainer(slPlane);
-
-        // Acquire lock on pose copy queue.
-        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
-        // Append data fetch container to the schedule queue.
-        m_qFloorCopySchedule.push(stContainer);
-        // Release lock on the pose schedule queue.
-        lkSchedulers.unlock();
-
-        // Check if pose queue toggle has already been set.
-        if (!m_bFloorsQueued.load(std::memory_order_relaxed))
-        {
-            // Signify that the pose queue is not empty.
-            m_bFloorsQueued.store(true, std::memory_order_relaxed);
-        }
-
-        // Return the future from the promise stored in the container.
-        return stContainer.pCopiedDataStatus->get_future();
-    }
-    else
-    {
-        // Release lock.
-        lkCameraLock.unlock();
-        // Submit logger message.
-        LOG_WARNING(logging::g_qSharedLogger, "Attempted to get ZED floor plane but positional tracking is not enabled!");
-
-        // Create dummy promise to return the future.
-        std::promise<bool> pmDummyPromise;
-        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
-        // Set future value.
-        pmDummyPromise.set_value(false);
-
-        // Return unsuccessful.
-        return fuDummyFuture;
-    }
-}
-
-/******************************************************************************
  * @brief Accessor for if the positional tracking functionality of the camera has been enabled
  *      and functioning.
  *
@@ -2224,124 +2428,4 @@ bool ZEDCam::GetObjectDetectionEnabled()
     // Acquire read lock.
     std::shared_lock<std::shared_mutex> lkCameraLock(m_muCameraMutex);
     return m_slCamera.isObjectDetectionEnabled();
-}
-
-/******************************************************************************
- * @brief Requests a current copy of the tracked objects from the camera.
- *      Puts a pointer to a vector containing sl::ObjectData into a queue so a copy of a frame from the camera can be written to it.
- *
- * @param vObjectData - A vector that will have data copied to it containing sl::ObjectData objects.
- * @return std::future<bool> - A future that should be waited on before the passed in vector is used.
- *                          Value will be true if data was successfully retrieved.
- *
- * @author clayjay3 (claytonraycowen@gmail.com)
- * @date 2023-08-27
- ******************************************************************************/
-std::future<bool> ZEDCam::RequestObjectsCopy(std::vector<sl::ObjectData>& vObjectData)
-{
-    // Acquire read lock.
-    std::shared_lock<std::shared_mutex> lkCameraLock(m_muCameraMutex);
-    // Check if object detection has been enabled.
-    if (m_slCamera.isObjectDetectionEnabled())
-    {
-        // Release lock.
-        lkCameraLock.unlock();
-        // Assemble the data container.
-        containers::DataFetchContainer<std::vector<sl::ObjectData>> stContainer(vObjectData);
-
-        // Acquire lock on object copy queue.
-        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
-        // Append data fetch container to the schedule queue.
-        m_qObjectDataCopySchedule.push(stContainer);
-        // Release lock on the object schedule queue.
-        lkSchedulers.unlock();
-
-        // Check if objects queue toggle has already been set.
-        if (!m_bObjectsQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
-        {
-            // Signify that the objects queue is not empty.
-            m_bObjectsQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
-        }
-
-        // Return the future from the promise stored in the container.
-        return stContainer.pCopiedDataStatus->get_future();
-    }
-    else
-    {
-        // Release lock.
-        lkCameraLock.unlock();
-        // Submit logger message.
-        LOG_WARNING(logging::g_qSharedLogger, "Attempted to get ZED object data but object detection/tracking is not enabled!");
-
-        // Create dummy promise to return the future.
-        std::promise<bool> pmDummyPromise;
-        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
-        // Set future value.
-        pmDummyPromise.set_value(false);
-
-        // Return unsuccessful.
-        return fuDummyFuture;
-    }
-}
-
-/******************************************************************************
- * @brief If batching is enabled, this requests the normal objects and passes them to
- *  the the internal batching queue of the zed api. This performs short-term re-identification
- *  with deep learning and trajectories filtering. Batching must have been set to enabled when
- *  EnableObjectDetection() was called. Most of the time the vector will be empty and will be
- *  filled every ZED_OBJDETECTION_BATCH_LATENCY.
- *
- * @param vBatchedObjectData - A vector containing objects of sl::ObjectsBatch object that will
- *                              have object data copied to.
- * @return std::future<bool> - A future that should be waited on before the passed in vector is used.
- *                          Value will be true if data was successfully retrieved.
- *
- * @author clayjay3 (claytonraycowen@gmail.com)
- * @date 2023-08-30
- ******************************************************************************/
-std::future<bool> ZEDCam::RequestBatchedObjectsCopy(std::vector<sl::ObjectsBatch>& vBatchedObjectData)
-{
-    // Acquire read lock.
-    std::shared_lock<std::shared_mutex> lkCameraLock(m_muCameraMutex);
-    // Check if object detection and batching has been enabled.
-    if (m_slCamera.isObjectDetectionEnabled() && m_slObjectDetectionBatchParams.enable)
-    {
-        // Release lock.
-        lkCameraLock.unlock();
-        // Assemble the data container.
-        containers::DataFetchContainer<std::vector<sl::ObjectsBatch>> stContainer(vBatchedObjectData);
-
-        // Acquire lock on batched object copy queue.
-        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
-        // Append data fetch container to the schedule queue.
-        m_qObjectBatchedDataCopySchedule.push(stContainer);
-        // Release lock on the data schedule queue.
-        lkSchedulers.unlock();
-
-        // Check if objects queue toggle has already been set.
-        if (!m_bBatchedObjectsQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
-        {
-            // Signify that the objects queue is not empty.
-            m_bBatchedObjectsQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
-        }
-
-        // Return the future from the promise stored in the container.
-        return stContainer.pCopiedDataStatus->get_future();
-    }
-    else
-    {
-        // Release lock.
-        lkCameraLock.unlock();
-        // Submit logger message.
-        LOG_WARNING(logging::g_qSharedLogger, "Attempted to get ZED batched object data but object detection/tracking is not enabled!");
-
-        // Create dummy promise to return the future.
-        std::promise<bool> pmDummyPromise;
-        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
-        // Set future value.
-        pmDummyPromise.set_value(false);
-
-        // Return unsuccessful.
-        return fuDummyFuture;
-    }
 }

--- a/src/vision/cameras/ZEDCam.h
+++ b/src/vision/cameras/ZEDCam.h
@@ -55,6 +55,12 @@ class ZEDCam : public ZEDCamera
         std::future<bool> RequestDepthCopy(cv::cuda::GpuMat& cvGPUDepth, const bool bRetrieveMeasure = true) override;
         std::future<bool> RequestPointCloudCopy(cv::Mat& cvPointCloud) override;
         std::future<bool> RequestPointCloudCopy(cv::cuda::GpuMat& cvGPUPointCloud) override;
+        std::future<bool> RequestPositionalPoseCopy(Pose& stPose) override;
+        std::future<bool> RequestFusionGeoPoseCopy(sl::GeoPose& slGeoPose) override;
+        std::future<bool> RequestFloorPlaneCopy(sl::Plane& slPlane) override;
+        std::future<bool> RequestSensorsCopy(sl::SensorsData& slSensorsData) override;
+        std::future<bool> RequestObjectsCopy(std::vector<sl::ObjectData>& vObjectData) override;
+        std::future<bool> RequestBatchedObjectsCopy(std::vector<sl::ObjectsBatch>& vBatchedObjectData) override;
         sl::ERROR_CODE ResetPositionalTracking() override;
         sl::ERROR_CODE TrackCustomBoxObjects(std::vector<ZedObjectData>& vCustomObjects) override;
         sl::ERROR_CODE RebootCamera() override;
@@ -82,17 +88,12 @@ class ZEDCam : public ZEDCamera
         bool GetUsingGPUMem() const override;
         std::string GetCameraModel() override;
         unsigned int GetCameraSerial() override;
-        std::future<bool> RequestPositionalPoseCopy(Pose& stPose) override;
-        std::future<bool> RequestFusionGeoPoseCopy(sl::GeoPose& slGeoPose) override;
-        std::future<bool> RequestFloorPlaneCopy(sl::Plane& slPlane) override;
         bool GetPositionalTrackingEnabled() override;
         sl::PositionalTrackingStatus GetPositionalTrackingState() override;
         sl::FusedPositionalTrackingStatus GetFusedPositionalTrackingState() override;
         sl::SPATIAL_MAPPING_STATE GetSpatialMappingState() override;
         sl::SPATIAL_MAPPING_STATE ExtractSpatialMapAsync(std::future<sl::Mesh>& fuMeshFuture) override;
         bool GetObjectDetectionEnabled() override;
-        std::future<bool> RequestObjectsCopy(std::vector<sl::ObjectData>& vObjectData) override;
-        std::future<bool> RequestBatchedObjectsCopy(std::vector<sl::ObjectsBatch>& vBatchedObjectData) override;
 
     private:
         /////////////////////////////////////////
@@ -116,6 +117,7 @@ class ZEDCam : public ZEDCamera
         sl::GeoPose m_slFusionGeoPose;
         sl::Plane m_slFloorPlane;
         sl::Transform m_slFloorTrackingTransform;
+        sl::SensorsData m_slSensorsData;
         sl::SpatialMappingParameters m_slSpatialMappingParams;
         sl::ObjectDetectionParameters m_slObjectDetectionParams;
         sl::BatchParameters m_slObjectDetectionBatchParams;
@@ -152,6 +154,7 @@ class ZEDCam : public ZEDCamera
         std::queue<containers::DataFetchContainer<Pose>> m_qPoseCopySchedule;
         std::queue<containers::DataFetchContainer<sl::GeoPose>> m_qGeoPoseCopySchedule;
         std::queue<containers::DataFetchContainer<sl::Plane>> m_qFloorCopySchedule;
+        std::queue<containers::DataFetchContainer<sl::SensorsData>> m_qSensorsCopySchedule;
         std::queue<containers::DataFetchContainer<std::vector<sl::ObjectData>>> m_qObjectDataCopySchedule;
         std::queue<containers::DataFetchContainer<std::vector<sl::ObjectsBatch>>> m_qObjectBatchedDataCopySchedule;
 
@@ -161,6 +164,7 @@ class ZEDCam : public ZEDCamera
         std::shared_mutex m_muPoseCopyMutex;
         std::shared_mutex m_muGeoPoseCopyMutex;
         std::shared_mutex m_muFloorCopyMutex;
+        std::shared_mutex m_muSensorsCopyMutex;
         std::shared_mutex m_muObjectDataCopyMutex;
         std::shared_mutex m_muObjectBatchedDataCopyMutex;
 
@@ -172,6 +176,7 @@ class ZEDCam : public ZEDCamera
         std::atomic<bool> m_bPosesQueued;
         std::atomic<bool> m_bGeoPosesQueued;
         std::atomic<bool> m_bFloorsQueued;
+        std::atomic<bool> m_bSensorsQueued;
         std::atomic<bool> m_bObjectsQueued;
         std::atomic<bool> m_bBatchedObjectsQueued;
 

--- a/src/vision/cameras/sim/SIMZEDCam.cpp
+++ b/src/vision/cameras/sim/SIMZEDCam.cpp
@@ -288,10 +288,10 @@ void SIMZEDCam::ThreadedContinuousCode()
     // Acquire a shared_lock on the frame copy queue.
     std::shared_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
     // Check if the frame copy queue is empty.
-    if (!m_qFrameCopySchedule.empty() || !m_qPoseCopySchedule.empty() || !m_qGeoPoseCopySchedule.empty())
+    if (!m_qFrameCopySchedule.empty() || !m_qPoseCopySchedule.empty() || !m_qGeoPoseCopySchedule.empty() || !m_qSensorsCopySchedule.empty())
     {
         // Add the length of all queues together to determine the number of tasks to create.
-        size_t siTotalQueueLength = m_qFrameCopySchedule.size() + m_qPoseCopySchedule.size() + m_qGeoPoseCopySchedule.size();
+        size_t siTotalQueueLength = m_qFrameCopySchedule.size() + m_qPoseCopySchedule.size() + m_qGeoPoseCopySchedule.size() + m_qSensorsCopySchedule.size();
 
         // Acquire shared lock on the WebRTC mutex, so that the WebRTC connection doesn't try to write to the Mats while they are being copied in the thread pool.
         std::shared_lock<std::shared_mutex> lkWebRTC(m_muWebRTCRGBImageCopyMutex);
@@ -310,6 +310,7 @@ void SIMZEDCam::ThreadedContinuousCode()
             // Reset queue counters.
             m_bPosesQueued.store(false, ATOMIC_MEMORY_ORDER_METHOD);
             m_bGeoPosesQueued.store(false, ATOMIC_MEMORY_ORDER_METHOD);
+            m_bSensorsQueued.store(false, ATOMIC_MEMORY_ORDER_METHOD);
 
             // Set reset toggle.
             bQueueTogglesAlreadyReset = true;
@@ -469,6 +470,33 @@ void SIMZEDCam::PooledLinearCode()
         // Release lock.
         lkGeoPoseQueue.unlock();
     }
+
+    /////////////////////////////
+    //  Sensors queue.
+    /////////////////////////////
+    // Acquire mutex for getting data out of the sensors queue.
+    std::unique_lock<std::shared_mutex> lkSensorsQueue(m_muSensorsCopyMutex);
+    // Check if the queue is empty.
+    if (!m_qSensorsCopySchedule.empty())
+    {
+        // Get pose container out of queue.
+        containers::DataFetchContainer<sl::SensorsData> stContainer = m_qSensorsCopySchedule.front();
+        // Pop out of queue.
+        m_qSensorsCopySchedule.pop();
+        // Release lock.
+        lkSensorsQueue.unlock();
+
+        // Copy pose.
+        *(stContainer.pData) = m_stIMUData;
+
+        // Signal future that the data has been successfully retrieved.
+        stContainer.pCopiedDataStatus->set_value(true);
+    }
+    else
+    {
+        // Release lock.
+        lkSensorsQueue.unlock();
+    }
 }
 
 /******************************************************************************
@@ -563,6 +591,139 @@ std::future<bool> SIMZEDCam::RequestPointCloudCopy(cv::Mat& cvPointCloud)
 
     // Return the future from the promise stored in the container.
     return stContainer.pCopiedFrameStatus->get_future();
+}
+
+/******************************************************************************
+ * @brief Puts a sl::GeoPose pointer into a queue so a copy of a GeoPose from the camera can be written to it.
+ *
+ * @param stPose - A reference to the sl::GeoPose to store the GeoPose in.
+ * @return std::future<bool> - A future that should be waited on before the passed in GeoPose is used.
+ *
+ * @author clayjay3 (claytonraycowen@gmail.com)
+ * @date 2024-12-26
+ ******************************************************************************/
+std::future<bool> SIMZEDCam::RequestPositionalPoseCopy(ZEDCamera::Pose& stPose)
+{
+    // Check if positional tracking is enabled.
+    if (m_bCameraPositionalTrackingEnabled)
+    {
+        // Assemble the data container.
+        containers::DataFetchContainer<Pose> stContainer(stPose);
+
+        // Acquire lock on pose copy queue.
+        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
+        // Append pose fetch container to the schedule queue.
+        m_qPoseCopySchedule.push(stContainer);
+        // Release lock on the pose schedule queue.
+        lkSchedulers.unlock();
+
+        // Check if pose queue toggle has already been set.
+        if (!m_bPosesQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
+        {
+            // Signify that the pose queue is not empty.
+            m_bPosesQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
+        }
+
+        // Return the future from the promise stored in the container.
+        return stContainer.pCopiedDataStatus->get_future();
+    }
+    else
+    {
+        // Submit logger message.
+        LOG_WARNING(logging::g_qSharedLogger, "Attempted to get ZED positional pose but positional tracking is not enabled or is still initializing!");
+
+        // Create dummy promise to return the future.
+        std::promise<bool> pmDummyPromise;
+        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
+        // Set future value.
+        pmDummyPromise.set_value(false);
+
+        // Return unsuccessful.
+        return fuDummyFuture;
+    }
+}
+
+/******************************************************************************
+ * @brief Puts a sl::GeoPose pointer into a queue so a copy of a GeoPose from the camera can be written to it.
+ *
+ * @param slGeoPose - A reference to the sl::GeoPose to store the GeoPose in.
+ * @return std::future<bool> - A future that should be waited on before the passed in GeoPose is used.
+ *
+ * @author clayjay3 (claytonraycowen@gmail.com)
+ * @date 2024-12-26
+ ******************************************************************************/
+std::future<bool> SIMZEDCam::RequestFusionGeoPoseCopy(sl::GeoPose& slGeoPose)
+{
+    // Check if positional tracking has been enabled.
+    if (m_bCameraIsFusionMaster && m_bCameraPositionalTrackingEnabled)
+    {
+        // Assemble the data container.
+        containers::DataFetchContainer<sl::GeoPose> stContainer(slGeoPose);
+
+        // Acquire lock on frame copy queue.
+        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
+        // Append frame fetch container to the schedule queue.
+        m_qGeoPoseCopySchedule.push(stContainer);
+        // Release lock on the frame schedule queue.
+        lkSchedulers.unlock();
+
+        // Check if pose queue toggle has already been set.
+        if (!m_bGeoPosesQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
+        {
+            // Signify that the pose queue is not empty.
+            m_bGeoPosesQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
+        }
+
+        // Return the future from the promise stored in the container.
+        return stContainer.pCopiedDataStatus->get_future();
+    }
+    else
+    {
+        // Submit logger message.
+        LOG_WARNING(logging::g_qSharedLogger,
+                    "Attempted to get ZED FUSION geo pose but positional tracking is not enabled and/or this camera was not initialized as a Fusion Master!");
+
+        // Create dummy promise to return the future.
+        std::promise<bool> pmDummyPromise;
+        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
+        // Set future value.
+        pmDummyPromise.set_value(false);
+
+        // Return unsuccessful.
+        return fuDummyFuture;
+    }
+}
+
+/******************************************************************************
+ * @brief Requests a copy of the sensors data from the camera.
+ *
+ * @param slSensorsData - A reference to the sl::SensorsData to store the sensors data in.
+ * @return std::future<bool> - A future that should be waited on before the passed in sensors data is used.
+ *
+ * @author clayjay3 (claytonraycowen@gmail.com)
+ * @date 2025-08-26
+ ******************************************************************************/
+std::future<bool> SIMZEDCam::RequestSensorsCopy(sl::SensorsData& slSensorsData)
+{
+    // Assemble the DataFetchContainer.
+    containers::DataFetchContainer<sl::SensorsData> stContainer(slSensorsData);
+
+    // Acquire lock on data copy queue.
+    std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
+    // Append data fetch container to the schedule queue.
+    m_qSensorsCopySchedule.push(stContainer);
+    // Release lock on the data schedule queue.
+    lkSchedulers.unlock();
+
+    // Check if pose queue toggle has already been set.
+    if (!m_bSensorsQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
+    {
+        // Signify that the pose queue is not empty.
+        m_bSensorsQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
+    }
+
+    // Return the future from the promise stored in the container.
+    return stContainer.pCopiedDataStatus->get_future();
 }
 
 /******************************************************************************
@@ -759,107 +920,6 @@ bool SIMZEDCam::GetUsingGPUMem() const
 std::string SIMZEDCam::GetCameraModel()
 {
     return "SIMZED2i";
-}
-
-/******************************************************************************
- * @brief Puts a sl::GeoPose pointer into a queue so a copy of a GeoPose from the camera can be written to it.
- *
- * @param stPose - A reference to the sl::GeoPose to store the GeoPose in.
- * @return std::future<bool> - A future that should be waited on before the passed in GeoPose is used.
- *
- * @author clayjay3 (claytonraycowen@gmail.com)
- * @date 2024-12-26
- ******************************************************************************/
-std::future<bool> SIMZEDCam::RequestPositionalPoseCopy(ZEDCamera::Pose& stPose)
-{
-    // Check if positional tracking is enabled.
-    if (m_bCameraPositionalTrackingEnabled)
-    {
-        // Assemble the data container.
-        containers::DataFetchContainer<Pose> stContainer(stPose);
-
-        // Acquire lock on pose copy queue.
-        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
-        // Append pose fetch container to the schedule queue.
-        m_qPoseCopySchedule.push(stContainer);
-        // Release lock on the pose schedule queue.
-        lkSchedulers.unlock();
-
-        // Check if pose queue toggle has already been set.
-        if (!m_bPosesQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
-        {
-            // Signify that the pose queue is not empty.
-            m_bPosesQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
-        }
-
-        // Return the future from the promise stored in the container.
-        return stContainer.pCopiedDataStatus->get_future();
-    }
-    else
-    {
-        // Submit logger message.
-        LOG_WARNING(logging::g_qSharedLogger, "Attempted to get ZED positional pose but positional tracking is not enabled or is still initializing!");
-
-        // Create dummy promise to return the future.
-        std::promise<bool> pmDummyPromise;
-        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
-        // Set future value.
-        pmDummyPromise.set_value(false);
-
-        // Return unsuccessful.
-        return fuDummyFuture;
-    }
-}
-
-/******************************************************************************
- * @brief Puts a sl::GeoPose pointer into a queue so a copy of a GeoPose from the camera can be written to it.
- *
- * @param slGeoPose - A reference to the sl::GeoPose to store the GeoPose in.
- * @return std::future<bool> - A future that should be waited on before the passed in GeoPose is used.
- *
- * @author clayjay3 (claytonraycowen@gmail.com)
- * @date 2024-12-26
- ******************************************************************************/
-std::future<bool> SIMZEDCam::RequestFusionGeoPoseCopy(sl::GeoPose& slGeoPose)
-{
-    // Check if positional tracking has been enabled.
-    if (m_bCameraIsFusionMaster && m_bCameraPositionalTrackingEnabled)
-    {
-        // Assemble the data container.
-        containers::DataFetchContainer<sl::GeoPose> stContainer(slGeoPose);
-
-        // Acquire lock on frame copy queue.
-        std::unique_lock<std::shared_mutex> lkSchedulers(m_muPoolScheduleMutex);
-        // Append frame fetch container to the schedule queue.
-        m_qGeoPoseCopySchedule.push(stContainer);
-        // Release lock on the frame schedule queue.
-        lkSchedulers.unlock();
-
-        // Check if pose queue toggle has already been set.
-        if (!m_bGeoPosesQueued.load(ATOMIC_MEMORY_ORDER_METHOD))
-        {
-            // Signify that the pose queue is not empty.
-            m_bGeoPosesQueued.store(true, ATOMIC_MEMORY_ORDER_METHOD);
-        }
-
-        // Return the future from the promise stored in the container.
-        return stContainer.pCopiedDataStatus->get_future();
-    }
-    else
-    {
-        // Submit logger message.
-        LOG_WARNING(logging::g_qSharedLogger,
-                    "Attempted to get ZED FUSION geo pose but positional tracking is not enabled and/or this camera was not initialized as a Fusion Master!");
-
-        // Create dummy promise to return the future.
-        std::promise<bool> pmDummyPromise;
-        std::future<bool> fuDummyFuture = pmDummyPromise.get_future();
-        // Set future value.
-        pmDummyPromise.set_value(false);
-
-        // Return unsuccessful.
-        return fuDummyFuture;
-    }
 }
 
 /******************************************************************************

--- a/src/vision/cameras/sim/SIMZEDCam.h
+++ b/src/vision/cameras/sim/SIMZEDCam.h
@@ -50,6 +50,9 @@ class SIMZEDCam : public ZEDCamera
         std::future<bool> RequestFrameCopy(cv::Mat& cvFrame) override;
         std::future<bool> RequestDepthCopy(cv::Mat& cvDepth, const bool bRetrieveMeasure = true);
         std::future<bool> RequestPointCloudCopy(cv::Mat& cvPointCloud);
+        std::future<bool> RequestPositionalPoseCopy(Pose& stPose) override;
+        std::future<bool> RequestFusionGeoPoseCopy(sl::GeoPose& slGeoPose) override;
+        std::future<bool> RequestSensorsCopy(sl::SensorsData& slSensorsData) override;
         sl::ERROR_CODE ResetPositionalTracking() override;
         sl::ERROR_CODE RebootCamera() override;
         sl::FUSION_ERROR_CODE SubscribeFusionToCameraUUID(sl::CameraIdentifier& slCameraUUID) override;
@@ -70,8 +73,6 @@ class SIMZEDCam : public ZEDCamera
         bool GetCameraIsOpen() override;
         bool GetUsingGPUMem() const override;
         std::string GetCameraModel() override;
-        std::future<bool> RequestPositionalPoseCopy(Pose& stPose) override;
-        std::future<bool> RequestFusionGeoPoseCopy(sl::GeoPose& slGeoPose) override;
         bool GetPositionalTrackingEnabled() override;
 
     private:
@@ -93,6 +94,9 @@ class SIMZEDCam : public ZEDCamera
 
         std::string m_szCameraPath;
         std::atomic<bool> m_bCameraPositionalTrackingEnabled;
+
+        // Simulated IMU Data from the SIM.
+        sl::SensorsData m_stIMUData;
 
         // WebRTC connections for each camera stream from the RoveSoSimulator.
 
@@ -123,6 +127,7 @@ class SIMZEDCam : public ZEDCamera
 
         std::queue<containers::DataFetchContainer<Pose>> m_qPoseCopySchedule;
         std::queue<containers::DataFetchContainer<sl::GeoPose>> m_qGeoPoseCopySchedule;
+        std::queue<containers::DataFetchContainer<sl::SensorsData>> m_qSensorsCopySchedule;
 
         // Mutexes for copying frames from the WebRTC connection to the OpenCV Mats.
 
@@ -132,10 +137,12 @@ class SIMZEDCam : public ZEDCamera
         // Mutexes for copying frames from the ZEDSDK to the OpenCV Mats in PoolLinearCode.
         std::shared_mutex m_muPoseCopyMutex;
         std::shared_mutex m_muGeoPoseCopyMutex;
+        std::shared_mutex m_muSensorsCopyMutex;
 
         // Atomic flags for checking if data is queued.
 
         std::atomic<bool> m_bPosesQueued;
         std::atomic<bool> m_bGeoPosesQueued;
+        std::atomic<bool> m_bSensorsQueued;
 };
 #endif


### PR DESCRIPTION
# Description

Adds asynchronous copy APIs for sensor, floor, pose, and object data to the ZED camera codepath (and the simulated ZED). Callers can request copies via `Request*Copy(...)` which return `std::future<bool>` the camera thread-pool services requests and fulfills promises with the most recent data.

# Changes

* New `Request*Copy` virtual APIs on `ZEDCamera` (sensors, floor plane, geo-pose, pose, objects, batched objects).
* Implementations in `ZEDCam.cpp` and `SIMZEDCam`: queueing, thread-pool handling, and promise/future fulfillment.
* Added internal storage + queues/mutexes/atomics to hold latest sensor/floor/pose/object data and pending requests.
* Example updated (`OpenZEDCam`) to demonstrate `RequestSensorsCopy` usage and log unpacked sensor fields.
* Minor CMake adjustment for `BUILD_SIM_MODE`.

# How it works

1. Caller calls `RequestSensorsCopy(target)` -> gets `std::future<bool>`.
2. Request wrapped into `DataFetchContainer<T>` and pushed onto a camera-local queue; an atomic flag signals worker threads.
3. Worker copies the latest internal value into the caller’s container and sets the promise to `true` (or immediately returns a `false` future if capability is disabled).

# Testing (recommended / observed)

* No new unit tests in this patch.
* Tested with ZED 2i stereo camera and confirmed sensors data is retrieved successfully.

# Known Issues
The SIMZEDCamera methods for retrieving the sensors data is not implemented yet. I will eventually add a feature to the sim that will send us emulated data. When I do this, I will also update the SIMZEDCam class so that we can use it with Autonomy_Software is built in SIM_MODE.
